### PR TITLE
Added Ordinal feature

### DIFF
--- a/lambda/custom/state_handlers.js
+++ b/lambda/custom/state_handlers.js
@@ -369,28 +369,53 @@ var scout_agent = (function() {
 })();
 
 function matchArticleToTitlesHelper(stateObj) {
-  let searchTerm = getTitleFromSlotEvent(stateObj.event);
-  if (searchTerm) {
-    let thisVar = stateObj;
-    findBestScoringTitle(
-      searchTerm,
-      stateObj.attributes['titles'].articles
-    ).then(
-      function(article) {
-        thisVar.attributes['chosenArticle'] = article.resolved_url;
-        thisVar.response
-          .speak(constants.strings.TITLE_CHOOSE_SUMM_FULL)
-          .listen(constants.strings.TITLE_CHOICE_REPROMPT);
-        thisVar.emit(':responseReady');
-      },
-      function(rejectReason) {
-        thisVar.response
-          .speak(constants.strings.TITLE_SEARCH_MATCH_FAIL)
-          .listen(constants.strings.TITLE_SEARCH_MATCH_FAIL);
-        thisVar.attributes['chosenArticle'] = '';
-        thisVar.emit(':responseReady');
-      }
-    );
+  let id = getOrdinalIntent(stateObj.event);
+  if (id >= 0) {
+    console.log('Ordinal intent : ' + id);
+    if (id >= stateObj.attributes['titleCount']) {
+      // Three cases there :
+      // titleCount = 0
+      //  - and the user has non-empty pocket list, do we have to fetch titles?
+      //  - and the user has empty pocket list
+      // titleCount > 0 but the user asks for a too high id number
+      console.log('Error: asking for a higher id than articles');
+      stateObj.response
+        .speak(constants.strings.TITLE_SEARCH_MATCH_FAIL)
+        .listen(constants.strings.TITLE_SEARCH_MATCH_FAIL);
+      stateObj.attributes['chosenArticle'] = '';
+      stateObj.emit(':responseReady');
+    } else {
+      stateObj.attributes['chosenArticle'] =
+        stateObj.attributes['titles'].articles[id].resolved_url;
+      stateObj.response
+        .speak(constants.strings.TITLE_CHOOSE_SUMM_FULL)
+        .listen(constants.strings.TITLE_CHOICE_REPROMPT);
+      stateObj.emit(':responseReady');
+    }
+  } else {
+    let searchTerm = getTitleFromSlotEvent(stateObj.event);
+    if (searchTerm) {
+      let thisVar = stateObj;
+      findBestScoringTitle(
+        searchTerm,
+        stateObj.attributes['titles'].articles
+      ).then(
+        function(article) {
+          thisVar.attributes['chosenArticle'] = article.resolved_url;
+          thisVar.response
+            .speak(constants.strings.TITLE_CHOOSE_SUMM_FULL)
+            .listen(constants.strings.TITLE_CHOICE_REPROMPT);
+          thisVar.emit(':responseReady');
+        },
+        function(rejectReason) {
+          thisVar.response
+            .speak(constants.strings.TITLE_SEARCH_MATCH_FAIL)
+            .listen(constants.strings.TITLE_SEARCH_MATCH_FAIL);
+          thisVar.attributes['chosenArticle'] = '';
+          thisVar.emit(':responseReady');
+        }
+      );
+    }
   }
 }
 
@@ -540,13 +565,35 @@ function cleanStringForSsml(alexaString) {
   return cleanedString;
 }
 
+function getOrdinalIntent(event) {
+  let slots = event.request.intent.slots;
+  for (var p in slots) {
+    if (slots.hasOwnProperty(p)) {
+      if (p == 'Ordinal' && slots[p].value) {
+        let possibleIds = ['1', '2', '3', '4', '5'];
+        if (slots[p].resolutions.resolutionsPerAuthority[0].values) {
+          let id =
+            slots[p].resolutions.resolutionsPerAuthority[0].values[0].value.id;
+          if (id in possibleIds) {
+            return id;
+          }
+        } else {
+          // Intent is Ordinal but not a supported id
+          console.log('False positive: Ordinal detected but not a valid id');
+        }
+      }
+    }
+  }
+  return -1;
+}
+
 function getTitleFromSlotEvent(event) {
   let slots = event.request.intent.slots;
   let search = 0;
   for (var p in slots) {
     if (slots.hasOwnProperty(p)) {
       console.log(p + ': ' + slots[p].value);
-      if (p == 'CatchAllSlot') {
+      if (slots[p].value) {
         search = slots[p].value;
       }
     }

--- a/models/en-US.json
+++ b/models/en-US.json
@@ -37,14 +37,32 @@
           "name": "SearchAndPlayArticle",
           "slots": [
             {
+              "name": "Ordinal",
+              "type": "Ordinal"
+            },
+            {
               "name": "CatchAllSlot",
               "type": "AMAZON.SearchQuery"
             }
           ],
           "samples": [
-            "play that article about {CatchAllSlot}",
             "play the article about {CatchAllSlot}",
-            "Play {CatchAllSlot}"
+            "play that article about {CatchAllSlot}",
+            "play that article on {CatchAllSlot}",
+            "play the article on {CatchAllSlot}",
+
+            "play the {Ordinal} article",
+            "play the {Ordinal} one",
+            "play the {Ordinal}",
+            "play {Ordinal}",
+
+            "play the article {Ordinal}",
+            "play the number {Ordinal}",
+            "play number {Ordinal}",
+
+            "play that {CatchAllSlot} article",
+            "play the {CatchAllSlot} article",
+            "play {CatchAllSlot}"
           ]
         },
         {
@@ -74,7 +92,48 @@
           "samples": ["entire story", "full article", "full story"]
         }
       ],
-      "types": []
+      "types": [
+        {
+          "name": "Ordinal",
+          "values": [
+            {
+              "id": "0",
+              "name": {
+                "value": "first",
+                "synonyms": ["one"]
+              }
+            },
+            {
+              "id": "1",
+              "name": {
+                "value": "second",
+                "synonyms": ["two"]
+              }
+            },
+            {
+              "id": "2",
+              "name": {
+                "value": "third",
+                "synonyms": ["three"]
+              }
+            },
+            {
+              "id": "3",
+              "name": {
+                "value": "fourth",
+                "synonyms": ["four"]
+              }
+            },
+            {
+              "id": "4",
+              "name": {
+                "value": "fifth",
+                "synonyms": ["five", "last"]
+              }
+            }
+          ]
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
Referring to #41  

Added a Custom Slot named "Ordinal" in scout-alexa-intent

Should detect every "Play number one", "Play the first one", "Play the first"... Support numbers 1-5.
Sometimes a search term is detected as an Ordinal and shouldn't be, in this case we use the term as the search keyword.
