### PR TITLE
Return to START_MODE state after finished article

### DIFF
--- a/lambda/custom/audioEventHandlers.js
+++ b/lambda/custom/audioEventHandlers.js
@@ -17,7 +17,8 @@ var audioEventHandlers = Alexa.CreateStateHandler(constants.states.PLAY_MODE, {
     this.emit(':saveState', true);
   },
   PlaybackFinished: function() {
-    this.emit(':saveState', true);
+    this.handler.state = constants.states.START_MODE;
+    this.emit('FinishedArticle');
   },
   PlaybackStopped: function() {
     /*

--- a/lambda/custom/state_handlers.js
+++ b/lambda/custom/state_handlers.js
@@ -72,6 +72,10 @@ var state_handlers = {
         console.log('START_MODE:AMAZON.SessionEndedRequest');
         // No session ended logic
       },
+      FinishedArticle: function() {
+        console.log('START_MODE:FinishedArticle');
+        this.emit(':saveState', true);
+      },
       Unhandled: function() {
         console.log('START_MODE:Unhandled: ' + this.event.request.intent.name);
         this.response


### PR DESCRIPTION
Fixes #33 

I tried to give prompts to the user after an article is finished playing, but I was getting INVALID_RESPONSE errors (The following directives are not supported: Response may not contain an outputSpeech,Response may not contain an reprompt,Response may not have shouldEndSession set to false). After further research, apparently the TTS is not supported after an audio event (PlaybackFinished) : https://github.com/alexa/skill-sample-nodejs-audio-player/issues/71 so we can't give any prompts to the user...

So at the end of the article, I just reset the state to START_MODE.

