### PR TITLE
Make sure chosenArticle is empty when calling getTitles so error hand…

### DIFF
--- a/lambda/custom/state_handlers.js
+++ b/lambda/custom/state_handlers.js
@@ -410,7 +410,7 @@ async function searchAndPlayArticleHelper(stateObj) {
 //Handler to get the titles for Alexa to read
 function getTitlesHelper(stateObj) {
   console.log('ScoutTitles');
-  console.log('ChosenArticle is: ' + stateObj.attributes['chosenArticle']);
+  stateObj.attributes['chosenArticle'] = '';
   scout_agent.handle(stateObj.event).then(
     titles => {
       console.log('promise resolved');


### PR DESCRIPTION
…ling is correct.

This handles following error case:
1. user is listening to an article
2. Alexa Stop
3. Alexa Tell scout to get titles.
4. Alexa says "what do you want to listen to"
5. User responds with some garbage that Alexa can't understand because user did not use "play" intent and she maps us to the skim intent.
6. We have to pick up in the skim intent that no article was chosen and reprompt them telling them we couldn't find a match.