### PR TITLE
Fix bugs with next & repeat in title list

### DIFF
--- a/lambda/custom/constants.js
+++ b/lambda/custom/constants.js
@@ -32,6 +32,7 @@ module.exports = Object.freeze({
       ' a few keywords. For example, say “Play the one about polar bears.” ' +
       'Say “Get my titles” to hear the first 5 articles in Pocket queue, ' +
       'next to hear another 5 and repeat to hear them again.',
+    TITLE_PREFIX: 'Here are the next titles:',
     END_OF_TITLES: 'There are no more titles in your queue.',
     TITLE_ANN: 'Here are your titles: ',
     TITLE_SEARCH_MATCH_FAIL:

--- a/lambda/custom/constants.js
+++ b/lambda/custom/constants.js
@@ -32,7 +32,7 @@ module.exports = Object.freeze({
       ' a few keywords. For example, say “Play the one about polar bears.” ' +
       'Say “Get my titles” to hear the first 5 articles in Pocket queue, ' +
       'next to hear another 5 and repeat to hear them again.',
-    TITLE_POCKET: 'No more titles in your queue.',
+    END_OF_TITLES: 'There are no more titles in your queue.',
     TITLE_ANN: 'Here are your titles: ',
     TITLE_SEARCH_MATCH_FAIL:
       'Sorry, I couldn’t find a match.  Say Play followed by a few words in the title ' +

--- a/lambda/custom/state_handlers.js
+++ b/lambda/custom/state_handlers.js
@@ -256,18 +256,20 @@ var state_handlers = {
           this.attributes['titles'].articles,
           this
         );
-        let message = '';
+        let message;
+        let reprompt;
         if (!respTitles) {
-          message = constants.strings.END_OF_TITLES;
+          message = `${constants.strings.END_OF_TITLES} ${
+            constants.strings.TITLE_CHOICE_EXPLAIN
+          }`;
+          reprompt = constants.strings.TITLE_CHOICE_EXPLAIN;
         } else {
-          message =
-            'Here are the next titles: ' +
-            respTitles +
-            constants.strings.TITLE_CHOICE_EXPLAIN;
+          message = `${constants.strings.TITLE_PREFIX} ${respTitles} ${
+            constants.strings.TITLE_CHOICE_EXPLAIN
+          }`;
+          reprompt = constants.strings.TITLE_CHOICE_EXPLAIN_REPROMPT;
         }
-        this.response
-          .speak(message)
-          .listen(constants.strings.TITLE_CHOICE_EXPLAIN_REPROMPT);
+        this.response.speak(message).listen(reprompt);
 
         this.emit(':responseReady');
       },


### PR DESCRIPTION
Fixes #46 
Fixes #47 

#46 -- we were checking for empty string to indicate the end of titles but `getTitleChunk` was returning an ssml break tag.

#47 -- needed a little mod math to recognize end of list. also changed a string constant name for clarity. 