### PR TITLE
Added calls to API to store/get offsets

### DIFF
--- a/lambda/custom/audioEventHandlers.js
+++ b/lambda/custom/audioEventHandlers.js
@@ -30,7 +30,8 @@ var audioEventHandlers = Alexa.CreateStateHandler(constants.states.PLAY_MODE, {
     this.attributes['offsetInMilliseconds'] = getOffsetInMilliseconds.call(
       this
     );
-    this.emit(':saveState', true);
+    this.handler.state = constants.states.PLAY_MODE;
+    this.emitWithState('StoppedArticle');
   },
 
   PlaybackNearlyFinished: function() {

--- a/lambda/custom/state_handlers.js
+++ b/lambda/custom/state_handlers.js
@@ -126,10 +126,14 @@ var state_handlers = {
     'AMAZON.PauseIntent': function() {
       console.log('PLAY_MODE:AMAZON.PauseIntent');
       audio_controller.stop.call(this);
+      this.emit('StoppedArticle');
+    },
+    StoppedArticle: function() {
+      console.log('PLAY_MODE:StoppedArticle');
       if (this.attributes['full']) {
         scout_agent
           .updateArticleStatus(
-            this.event.session.user.accessToken,
+            this.attributes['userId'],
             this.attributes['articleId'],
             this.attributes['offsetInMilliseconds']
           )
@@ -137,6 +141,7 @@ var state_handlers = {
             console.log('Error during offset update.');
           });
       }
+      this.emit(':saveState', true);
     },
     'AMAZON.ResumeIntent': function() {
       console.log('PLAY_MODE:AMAZON.ResumeIntent');

--- a/lambda/custom/state_handlers.js
+++ b/lambda/custom/state_handlers.js
@@ -82,7 +82,7 @@ var state_handlers = {
               0
             )
             .catch(function(err) {
-              console.log('Error during offset update.');
+              console.log('Error during offset update:' + err);
             });
         }
         this.emit(':saveState', true);
@@ -402,15 +402,11 @@ var scout_agent = (function() {
     },
     getArticleStatus: function(userId, articleId) {
       return new Promise((resolve, reject) => {
-        console.log('getArticleStatus: ' + articleId + ' for ' + userId);
+        console.log(`getArticleStatus: ${articleId} for ${userId}`);
         let scoutOptions = {
-          uri:
-            'http://' +
-            process.env.SCOUT_ADDR +
-            '/article-status/' +
-            userId +
-            '/' +
-            articleId,
+          uri: `http://${
+            process.env.SCOUT_ADDR
+          }/article-status/${userId}/${articleId}`,
           method: 'GET',
           headers: {
             'Content-Type': 'application/json; charset=UTF-8',
@@ -612,22 +608,22 @@ function synthesisHelperUrl(stateObj) {
       }
     );
     console.log('Chosen Article is: ' + stateObj.attributes['chosenArticle']);
-    const getArticle = scout_agent.handleUrl(
+    const article = scout_agent.handleUrl(
       stateObj.attributes['chosenArticle'],
       stateObj.event
     );
     stateObj.attributes['full'] =
       stateObj.event.request.intent.name == 'fullarticle';
     stateObj.attributes['userId'] = stateObj.event.session.user.accessToken;
-    let getOffset;
+    let offset;
     if (stateObj.attributes['full']) {
-      getOffset = scout_agent.getArticleStatus(
+      offset = scout_agent.getArticleStatus(
         stateObj.event.session.user.accessToken,
         stateObj.attributes['articleId']
       );
     }
 
-    Promise.all([getArticle, getOffset])
+    Promise.all([article, offset])
       .then(function(values) {
         let url = values[0];
         console.log('promise resolved: ' + url.url);
@@ -643,7 +639,7 @@ function synthesisHelperUrl(stateObj) {
         stateObj.emit(':responseReady');
       });
 
-    Promise.all([directiveServiceCall, getArticle]).then(function(values) {
+    Promise.all([directiveServiceCall, article]).then(function(values) {
       console.log(values);
     });
   }

--- a/lambda/custom/state_handlers.js
+++ b/lambda/custom/state_handlers.js
@@ -82,7 +82,7 @@ var state_handlers = {
               0
             )
             .catch(function(err) {
-              console.log('Error during offset update:' + err);
+              console.log(`Error during offset update: ${err}`);
             });
         }
         this.emit(':saveState', true);
@@ -138,7 +138,7 @@ var state_handlers = {
             this.attributes['offsetInMilliseconds']
           )
           .catch(function(err) {
-            console.log('Error during offset update.');
+            console.log(`Error during offset update: ${err}`);
           });
       }
       this.emit(':saveState', true);
@@ -436,15 +436,10 @@ var scout_agent = (function() {
     updateArticleStatus: function(userId, articleId, offset) {
       return new Promise((resolve, reject) => {
         console.log(
-          'updateArticleStatus: ' +
-            articleId +
-            ' for ' +
-            userId +
-            '. Offset: ' +
-            offset
+          `updateArticleStatus: ${articleId} for ${userId}. Offset: ${offset}`
         );
         let scoutOptions = {
-          uri: 'http://' + process.env.SCOUT_ADDR + '/article-status/',
+          uri: `http://${process.env.SCOUT_ADDR}/article-status/`,
           method: 'POST',
           body: JSON.stringify({
             pocket_user_id: userId,
@@ -464,8 +459,8 @@ var scout_agent = (function() {
             resolve();
           })
           .catch(function(err) {
-            console.log('updateArticle unavailable');
-            reject('updateArticle Unavailable');
+            console.log(`updateArticle API unavailable: ${err}`);
+            reject(`updateArticle API unavailable: ${err}`);
           });
       });
     }
@@ -638,8 +633,7 @@ function synthesisHelperUrl(stateObj) {
         audio_controller.play.call(stateObj);
       })
       .catch(function(err) {
-        console.log('handleURL/Offset promise failed');
-        console.log(err);
+        console.log(`handleURL/Offset promise failed: ${err}`);
         stateObj.response.speak(constants.strings.ARTICLE_FAIL_MSG);
         stateObj.emit(':responseReady');
       });


### PR DESCRIPTION
Fixes #56 

As the backend only works for one type (only one storage per item_id), I only store offsets for full articles (not summaries).

I store the offset when the user pauses the content. Te next time the user plays the content, it will begin from this offset.
At the end of the article, I reset the offset to 0.