### PR TITLE
Added tests (and bug fixes)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 lambda/custom/node_modules/
+lambda/custom/.nyc_output/
+lambda/custom/coverage/
+.DS_Store
+*.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+node_js:
+  - "8.10"
+script: cd lambda/custom && npm install && npm run-script travis

--- a/README.md
+++ b/README.md
@@ -66,4 +66,7 @@ In Skills/Your Skills/Dev Skill you should see your Skill in development. Enable
 ## Testing
 
 Testing using [Bespoken virtual-alexa](https://github.com/bespoken/virtual-alexa).
+
+To run tests, you need to have the environment variables `JWOT_TOKEN` and `SCOUT_ADDR`. You also need to have AWS credentials.
+
 To run tests manually: `npm test`

--- a/lambda/custom/constants.js
+++ b/lambda/custom/constants.js
@@ -53,6 +53,7 @@ module.exports = Object.freeze({
     ERROR_UNHANDLED_STATE:
       'Sorry, I could not understand. Please say, get titles to hear your titles.',
     ERROR_UNEXPECTED_STATE: 'Sorry, unhandled intent: in state: ',
+    ERROR_GETTING_TITLES: 'Error Getting titles',
     PLAY_MODE_UNHANDLED:
       'Sorry, I could not understand that.  ' +
       'You can say pause or resume or stop to control the audio',

--- a/lambda/custom/package-lock.json
+++ b/lambda/custom/package-lock.json
@@ -4,15 +4,147 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.0.0-beta.49",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.49.tgz",
+      "integrity": "sha1-vs2AVIJzREDJ0TfkbXc0DmTX9Rs=",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "7.0.0-beta.49"
+      }
+    },
+    "@babel/generator": {
+      "version": "7.0.0-beta.49",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.49.tgz",
+      "integrity": "sha1-6c/9qROZaszseTu8JauRvBnQv3o=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.0.0-beta.49",
+        "jsesc": "^2.5.1",
+        "lodash": "^4.17.5",
+        "source-map": "^0.5.0",
+        "trim-right": "^1.0.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.0.0-beta.49",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.49.tgz",
+      "integrity": "sha1-olwRGbnwNSeGcBJuAiXAMEHI3jI=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "7.0.0-beta.49",
+        "@babel/template": "7.0.0-beta.49",
+        "@babel/types": "7.0.0-beta.49"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.0.0-beta.49",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.49.tgz",
+      "integrity": "sha1-z1Aj8y0q2S0Ic3STnOwJUby1FEE=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.0.0-beta.49"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.0.0-beta.49",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.49.tgz",
+      "integrity": "sha1-QNeO2glo0BGxxShm5XRs+yPldUg=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.0.0-beta.49"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.0.0-beta.49",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.49.tgz",
+      "integrity": "sha1-lr3GtD4TSCASumaRsQGEktOWIsw=",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.0",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.0"
+      }
+    },
+    "@babel/parser": {
+      "version": "7.0.0-beta.49",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.49.tgz",
+      "integrity": "sha1-lE0MW6KBK7FZ7b0iZ0Ov0mUXm9w=",
+      "dev": true
+    },
+    "@babel/template": {
+      "version": "7.0.0-beta.49",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.49.tgz",
+      "integrity": "sha1-44q+ghfLl5P0YaUwbXrXRdg+HSc=",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "7.0.0-beta.49",
+        "@babel/parser": "7.0.0-beta.49",
+        "@babel/types": "7.0.0-beta.49",
+        "lodash": "^4.17.5"
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.0.0-beta.49",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.49.tgz",
+      "integrity": "sha1-TypzaCoYM07WYl0QCo0nMZ98LWg=",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "7.0.0-beta.49",
+        "@babel/generator": "7.0.0-beta.49",
+        "@babel/helper-function-name": "7.0.0-beta.49",
+        "@babel/helper-split-export-declaration": "7.0.0-beta.49",
+        "@babel/parser": "7.0.0-beta.49",
+        "@babel/types": "7.0.0-beta.49",
+        "debug": "^3.1.0",
+        "globals": "^11.1.0",
+        "invariant": "^2.2.0",
+        "lodash": "^4.17.5"
+      }
+    },
+    "@babel/types": {
+      "version": "7.0.0-beta.49",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.49.tgz",
+      "integrity": "sha1-t+Oxw/TUz+Eb34yJ8e/V4WF7h6Y=",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.5",
+        "to-fast-properties": "^2.0.0"
+      }
+    },
+    "@types/node": {
+      "version": "10.3.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.3.4.tgz",
+      "integrity": "sha512-YMLlzdeNnAyLrQew39IFRkMacAR5BqKGIEei9ZjdHsIZtv+ZWKYTu1i7QJhetxQ9ReXx8w5f+cixdHZG3zgMQA==",
+      "dev": true
+    },
+    "@types/uuid": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.3.tgz",
+      "integrity": "sha512-5fRLCYhLtDb3hMWqQyH10qtF+Ud2JnNCXTCZ+9ktNdCcgslcuXkDTkFcJNk++MT29yDntDnlF1+jD+uVGumsbw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "ajv": {
       "version": "5.5.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "requires": {
-        "co": "4.6.0",
-        "fast-deep-equal": "1.1.0",
-        "fast-json-stable-stringify": "2.0.0",
-        "json-schema-traverse": "0.3.1"
+        "co": "^4.6.0",
+        "fast-deep-equal": "^1.0.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.3.0"
       }
     },
     "alexa-sdk": {
@@ -20,9 +152,18 @@
       "resolved": "https://registry.npmjs.org/alexa-sdk/-/alexa-sdk-1.0.25.tgz",
       "integrity": "sha512-+FVFNi+mxBZm2HL+oi5u4JTNjQ2uDs4Tp9eqcWIxL3AAD+AU4a6gWpu6LEjxIVCqaI1Ro/RyDm3mnJZA9g6G8w==",
       "requires": {
-        "aws-sdk": "2.224.1",
-        "i18next": "3.5.2",
-        "i18next-sprintf-postprocessor": "0.2.2"
+        "aws-sdk": "^2.4.7",
+        "i18next": "^3.4.1",
+        "i18next-sprintf-postprocessor": "^0.2.2"
+      }
+    },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^1.9.0"
       }
     },
     "apparatus": {
@@ -30,7 +171,16 @@
       "resolved": "https://registry.npmjs.org/apparatus/-/apparatus-0.0.9.tgz",
       "integrity": "sha1-N9zSWDStC2UQdllikduCPusZCL0=",
       "requires": {
-        "sylvester": "0.0.21"
+        "sylvester": ">= 0.0.8"
+      }
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
       }
     },
     "asn1": {
@@ -42,6 +192,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+    },
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
     },
     "asynckit": {
       "version": "0.4.0",
@@ -98,7 +254,7 @@
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
       "optional": true,
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "^0.14.3"
       }
     },
     "bindings": {
@@ -111,31 +267,29 @@
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
       "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
     },
-    "boom": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
-      "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
-      "requires": {
-        "hoek": "4.2.1"
-      }
-    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
+    },
+    "browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
     },
     "buffer": {
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "requires": {
-        "base64-js": "1.3.0",
-        "ieee754": "1.1.8",
-        "isarray": "1.0.0"
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
       }
     },
     "caseless": {
@@ -143,18 +297,64 @@
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
+    "chai": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
+      "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
+      "dev": true,
+      "requires": {
+        "assertion-error": "^1.0.1",
+        "check-error": "^1.0.1",
+        "deep-eql": "^3.0.0",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.0.0",
+        "type-detect": "^4.0.0"
+      }
+    },
+    "chalk": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+      "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      }
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true
+    },
     "cli": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/cli/-/cli-0.4.3.tgz",
       "integrity": "sha1-5oGcjV+qlX9k+Y9mqFBiaMHR8X0=",
       "requires": {
-        "glob": "7.1.2"
+        "glob": ">= 3.1.4"
       }
     },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+    },
+    "color-convert": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.2.tgz",
+      "integrity": "sha512-3NUJZdhMhcdPn8vJ9v2UQJoH0qqoGUkYTgFEPZaPjEtwmmKUfNV46zZmgB2M5M4DCEQHMaCfWHCxiBflLm04Tg==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.1"
+      }
+    },
+    "color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok=",
+      "dev": true
     },
     "colors": {
       "version": "1.2.1",
@@ -166,7 +366,7 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "requires": {
-        "delayed-stream": "1.0.0"
+        "delayed-stream": "~1.0.0"
       }
     },
     "commander": {
@@ -184,21 +384,24 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
-    "cryptiles": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
-      "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+    "coveralls": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.1.tgz",
+      "integrity": "sha512-FAzXwiDOYLGDWH+zgoIA+8GbWv50hlx+kpEJyvzLKOdnIBv9uWoVl4DhqGgyUHpiRjAlF8KYZSipWXYtllWH6Q==",
+      "dev": true,
       "requires": {
-        "boom": "5.2.0"
+        "js-yaml": "^3.6.1",
+        "lcov-parse": "^0.0.10",
+        "log-driver": "^1.2.5",
+        "minimist": "^1.2.0",
+        "request": "^2.79.0"
       },
       "dependencies": {
-        "boom": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-          "requires": {
-            "hoek": "4.2.1"
-          }
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
         }
       }
     },
@@ -207,13 +410,43 @@
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
+    },
+    "debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "^4.0.0"
+      }
+    },
+    "deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
+      "dev": true
     },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true
     },
     "ecc-jsbn": {
       "version": "0.1.1",
@@ -221,8 +454,26 @@
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
       "optional": true,
       "requires": {
-        "jsbn": "0.1.1"
+        "jsbn": "~0.1.0"
       }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "esprima": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true
     },
     "events": {
       "version": "1.1.1",
@@ -259,9 +510,9 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
       "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "requires": {
-        "asynckit": "0.4.0",
+        "asynckit": "^0.4.0",
         "combined-stream": "1.0.6",
-        "mime-types": "2.1.18"
+        "mime-types": "^2.1.12"
       }
     },
     "fs.realpath": {
@@ -274,24 +525,30 @@
       "resolved": "https://registry.npmjs.org/fuse/-/fuse-0.4.0.tgz",
       "integrity": "sha1-LDjq+IirsKm6eWDP4zOdHz9T9uY=",
       "requires": {
-        "colors": "1.2.1",
-        "jshint": "0.9.1",
-        "optimist": "0.6.1",
-        "uglify-js": "3.3.21",
-        "underscore": "1.8.3"
+        "colors": ">=0.6.x",
+        "jshint": "0.9.x",
+        "optimist": ">=0.3.5",
+        "uglify-js": ">=2.2.x",
+        "underscore": ">=1.4.x"
       }
     },
     "fuse.js": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-3.2.0.tgz",
-      "integrity": "sha1-8ESOgGmFW/Kj5oPNwdMg5+KgfvQ="
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-3.2.1.tgz",
+      "integrity": "sha1-YyDLlM5W7JdVyJred1vNuwNY1CU="
+    },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
     },
     "getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "glob": {
@@ -299,12 +556,12 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       },
       "dependencies": {
         "minimatch": {
@@ -312,10 +569,22 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "requires": {
-            "brace-expansion": "1.1.11"
+            "brace-expansion": "^1.1.7"
           }
         }
       }
+    },
+    "globals": {
+      "version": "11.7.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
+      "integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg==",
+      "dev": true
+    },
+    "growl": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+      "dev": true
     },
     "har-schema": {
       "version": "2.0.0",
@@ -327,34 +596,30 @@
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "requires": {
-        "ajv": "5.5.2",
-        "har-schema": "2.0.0"
+        "ajv": "^5.1.0",
+        "har-schema": "^2.0.0"
       }
     },
-    "hawk": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
-      "requires": {
-        "boom": "4.3.1",
-        "cryptiles": "3.1.2",
-        "hoek": "4.2.1",
-        "sntp": "2.1.0"
-      }
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
     },
-    "hoek": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-      "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
     },
     "http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "requires": {
-        "assert-plus": "1.0.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.14.1"
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "i18next": {
@@ -377,14 +642,23 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.0.0"
+      }
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -401,10 +675,47 @@
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
+    "istanbul-lib-coverage": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.0.tgz",
+      "integrity": "sha512-yMSw5xLIbdaxiVXHk3amfNM2WeBxLrwH/BCyZ9HvA/fylwziAIJOG2rKqWyLqEJqwKT725vxxqidv+SyynnGAA==",
+      "dev": true
+    },
+    "istanbul-lib-instrument": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-2.2.0.tgz",
+      "integrity": "sha512-ozQGtlIw+/a/F3n6QwWiuuyRAPp64+g2GVsKYsIez0sgIEzkU5ZpL2uZ5pmAzbEJ82anlRaPlOQZzkRXspgJyg==",
+      "dev": true,
+      "requires": {
+        "@babel/generator": "7.0.0-beta.49",
+        "@babel/parser": "7.0.0-beta.49",
+        "@babel/template": "7.0.0-beta.49",
+        "@babel/traverse": "7.0.0-beta.49",
+        "@babel/types": "7.0.0-beta.49",
+        "istanbul-lib-coverage": "^2.0.0",
+        "semver": "^5.5.0"
+      }
+    },
     "jmespath": {
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
       "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
+    },
+    "js-tokens": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
+      "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
     },
     "jsbn": {
       "version": "0.1.1",
@@ -412,13 +723,19 @@
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "optional": true
     },
+    "jsesc": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
+      "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
+      "dev": true
+    },
     "jshint": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/jshint/-/jshint-0.9.1.tgz",
       "integrity": "sha1-/zLsfwn4QAH3SY7q/WPJ5Puy3A4=",
       "requires": {
         "cli": "0.4.3",
-        "minimatch": "0.0.5"
+        "minimatch": "0.0.x"
       }
     },
     "json-schema": {
@@ -447,10 +764,31 @@
         "verror": "1.10.0"
       }
     },
+    "lcov-parse": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
+      "integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=",
+      "dev": true
+    },
     "lodash": {
       "version": "4.17.5",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
       "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+    },
+    "log-driver": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
+      "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
+      "dev": true
+    },
+    "loose-envify": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+      "dev": true,
+      "requires": {
+        "js-tokens": "^3.0.0"
+      }
     },
     "lru-cache": {
       "version": "1.0.6",
@@ -467,7 +805,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
       "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
       "requires": {
-        "mime-db": "1.33.0"
+        "mime-db": "~1.33.0"
       }
     },
     "minimatch": {
@@ -475,13 +813,66 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.0.5.tgz",
       "integrity": "sha1-lrtJC707poNrv6wRGt91MBsVhN4=",
       "requires": {
-        "lru-cache": "1.0.6"
+        "lru-cache": "~1.0.2"
       }
     },
     "minimist": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
       "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        }
+      }
+    },
+    "mocha": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
+      "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.1",
+        "commander": "2.15.1",
+        "debug": "3.1.0",
+        "diff": "3.5.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "growl": "1.10.5",
+        "he": "1.1.1",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "supports-color": "5.4.0"
+      },
+      "dependencies": {
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        }
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
     },
     "nan": {
       "version": "2.10.0",
@@ -493,10 +884,2080 @@
       "resolved": "https://registry.npmjs.org/natural/-/natural-0.5.1.tgz",
       "integrity": "sha1-maXIt/G+Cy1/mngD9Zb4zIRrWq8=",
       "requires": {
-        "apparatus": "0.0.9",
-        "sylvester": "0.0.21",
-        "underscore": "1.8.3",
-        "webworker-threads": "0.7.13"
+        "apparatus": ">= 0.0.9",
+        "sylvester": ">= 0.0.12",
+        "underscore": ">=1.3.1",
+        "webworker-threads": ">=0.6.2"
+      }
+    },
+    "nock": {
+      "version": "9.3.3",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-9.3.3.tgz",
+      "integrity": "sha512-FBgnx25er2ly7KBr0Est5F0z5g+lnyr6a72vZI1KMi7nTL4ojU6XpFhlrfw6CXRdnT2FA5i8exHiT1uVNUM1qA==",
+      "dev": true,
+      "requires": {
+        "chai": "^4.1.2",
+        "debug": "^3.1.0",
+        "deep-equal": "^1.0.0",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.5",
+        "mkdirp": "^0.5.0",
+        "propagate": "^1.0.0",
+        "qs": "^6.5.1",
+        "semver": "^5.5.0"
+      }
+    },
+    "nyc": {
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/nyc/-/nyc-12.0.2.tgz",
+      "integrity": "sha1-ikpO1pCWbBHsWH/4fuoMEsl0upk=",
+      "dev": true,
+      "requires": {
+        "archy": "^1.0.0",
+        "arrify": "^1.0.1",
+        "caching-transform": "^1.0.0",
+        "convert-source-map": "^1.5.1",
+        "debug-log": "^1.0.1",
+        "default-require-extensions": "^1.0.0",
+        "find-cache-dir": "^0.1.1",
+        "find-up": "^2.1.0",
+        "foreground-child": "^1.5.3",
+        "glob": "^7.0.6",
+        "istanbul-lib-coverage": "^1.2.0",
+        "istanbul-lib-hook": "^1.1.0",
+        "istanbul-lib-instrument": "^2.1.0",
+        "istanbul-lib-report": "^1.1.3",
+        "istanbul-lib-source-maps": "^1.2.5",
+        "istanbul-reports": "^1.4.1",
+        "md5-hex": "^1.2.0",
+        "merge-source-map": "^1.1.0",
+        "micromatch": "^3.1.10",
+        "mkdirp": "^0.5.0",
+        "resolve-from": "^2.0.0",
+        "rimraf": "^2.6.2",
+        "signal-exit": "^3.0.1",
+        "spawn-wrap": "^1.4.2",
+        "test-exclude": "^4.2.0",
+        "yargs": "11.1.0",
+        "yargs-parser": "^8.0.0"
+      },
+      "dependencies": {
+        "align-text": {
+          "version": "0.1.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2",
+            "longest": "^1.0.1",
+            "repeat-string": "^1.5.2"
+          }
+        },
+        "amdefine": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "ansi-regex": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "append-transform": {
+          "version": "0.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "default-require-extensions": "^1.0.0"
+          }
+        },
+        "archy": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "arr-diff": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "arr-flatten": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "arr-union": {
+          "version": "3.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "array-unique": {
+          "version": "0.3.2",
+          "bundled": true,
+          "dev": true
+        },
+        "arrify": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "assign-symbols": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "async": {
+          "version": "1.5.2",
+          "bundled": true,
+          "dev": true
+        },
+        "atob": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "base": {
+          "version": "0.11.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "cache-base": "^1.0.1",
+            "class-utils": "^0.3.5",
+            "component-emitter": "^1.2.1",
+            "define-property": "^1.0.0",
+            "isobject": "^3.0.1",
+            "mixin-deep": "^1.2.0",
+            "pascalcase": "^0.1.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^1.0.0"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
+              }
+            },
+            "kind-of": {
+              "version": "6.0.2",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "braces": {
+          "version": "2.3.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "builtin-modules": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "cache-base": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "collection-visit": "^1.0.0",
+            "component-emitter": "^1.2.1",
+            "get-value": "^2.0.6",
+            "has-value": "^1.0.0",
+            "isobject": "^3.0.1",
+            "set-value": "^2.0.0",
+            "to-object-path": "^0.3.0",
+            "union-value": "^1.0.0",
+            "unset-value": "^1.0.0"
+          }
+        },
+        "caching-transform": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "md5-hex": "^1.2.0",
+            "mkdirp": "^0.5.1",
+            "write-file-atomic": "^1.1.4"
+          }
+        },
+        "camelcase": {
+          "version": "1.2.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "center-align": {
+          "version": "0.1.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "align-text": "^0.1.3",
+            "lazy-cache": "^1.0.3"
+          }
+        },
+        "class-utils": {
+          "version": "0.3.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "arr-union": "^3.1.0",
+            "define-property": "^0.2.5",
+            "isobject": "^3.0.0",
+            "static-extend": "^0.1.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            }
+          }
+        },
+        "cliui": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "center-align": "^0.1.1",
+            "right-align": "^0.1.1",
+            "wordwrap": "0.0.2"
+          },
+          "dependencies": {
+            "wordwrap": {
+              "version": "0.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "collection-visit": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "map-visit": "^1.0.0",
+            "object-visit": "^1.0.0"
+          }
+        },
+        "commondir": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "component-emitter": {
+          "version": "1.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "convert-source-map": {
+          "version": "1.5.1",
+          "bundled": true,
+          "dev": true
+        },
+        "copy-descriptor": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "cross-spawn": {
+          "version": "4.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "which": "^1.2.9"
+          }
+        },
+        "debug": {
+          "version": "3.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "debug-log": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "decamelize": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "decode-uri-component": {
+          "version": "0.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "default-require-extensions": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "strip-bom": "^2.0.0"
+          }
+        },
+        "define-property": {
+          "version": "2.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.2",
+            "isobject": "^3.0.1"
+          },
+          "dependencies": {
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
+              }
+            },
+            "kind-of": {
+              "version": "6.0.2",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "error-ex": {
+          "version": "1.3.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-arrayish": "^0.2.1"
+          }
+        },
+        "execa": {
+          "version": "0.7.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^5.0.1",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          },
+          "dependencies": {
+            "cross-spawn": {
+              "version": "5.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "lru-cache": "^4.0.1",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
+              }
+            }
+          }
+        },
+        "expand-brackets": {
+          "version": "2.1.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "debug": "^2.3.3",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "posix-character-classes": "^0.1.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "define-property": {
+              "version": "0.2.5",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "extend-shallow": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "assign-symbols": "^1.0.0",
+            "is-extendable": "^1.0.1"
+          },
+          "dependencies": {
+            "is-extendable": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-plain-object": "^2.0.4"
+              }
+            }
+          }
+        },
+        "extglob": {
+          "version": "2.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "array-unique": "^0.3.2",
+            "define-property": "^1.0.0",
+            "expand-brackets": "^2.1.4",
+            "extend-shallow": "^2.0.1",
+            "fragment-cache": "^0.2.1",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^1.0.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
+              }
+            },
+            "kind-of": {
+              "version": "6.0.2",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "find-cache-dir": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "commondir": "^1.0.1",
+            "mkdirp": "^0.5.1",
+            "pkg-dir": "^1.0.0"
+          }
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "for-in": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "foreground-child": {
+          "version": "1.5.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^4",
+            "signal-exit": "^3.0.0"
+          }
+        },
+        "fragment-cache": {
+          "version": "0.2.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "map-cache": "^0.2.2"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "get-caller-file": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "get-stream": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "get-value": {
+          "version": "2.0.6",
+          "bundled": true,
+          "dev": true
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "bundled": true,
+          "dev": true
+        },
+        "handlebars": {
+          "version": "4.0.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "async": "^1.4.0",
+            "optimist": "^0.6.1",
+            "source-map": "^0.4.4",
+            "uglify-js": "^2.6"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.4.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "amdefine": ">=0.0.4"
+              }
+            }
+          }
+        },
+        "has-value": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "get-value": "^2.0.6",
+            "has-values": "^1.0.0",
+            "isobject": "^3.0.0"
+          }
+        },
+        "has-values": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-number": "^3.0.0",
+            "kind-of": "^4.0.0"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "4.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "hosted-git-info": {
+          "version": "2.6.0",
+          "bundled": true,
+          "dev": true
+        },
+        "imurmurhash": {
+          "version": "0.1.4",
+          "bundled": true,
+          "dev": true
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "invert-kv": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-accessor-descriptor": {
+          "version": "0.1.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          }
+        },
+        "is-arrayish": {
+          "version": "0.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "is-buffer": {
+          "version": "1.1.6",
+          "bundled": true,
+          "dev": true
+        },
+        "is-builtin-module": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "builtin-modules": "^1.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "0.1.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          }
+        },
+        "is-descriptor": {
+          "version": "0.1.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^0.1.6",
+            "is-data-descriptor": "^0.1.4",
+            "kind-of": "^5.0.0"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "5.1.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "is-extendable": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          }
+        },
+        "is-odd": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-number": "^4.0.0"
+          },
+          "dependencies": {
+            "is-number": {
+              "version": "4.0.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "is-plain-object": {
+          "version": "2.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "isobject": "^3.0.1"
+          }
+        },
+        "is-stream": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-utf8": {
+          "version": "0.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "is-windows": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "isexe": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "istanbul-lib-coverage": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "istanbul-lib-hook": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "append-transform": "^0.4.0"
+          }
+        },
+        "istanbul-lib-report": {
+          "version": "1.1.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "istanbul-lib-coverage": "^1.1.2",
+            "mkdirp": "^0.5.1",
+            "path-parse": "^1.0.5",
+            "supports-color": "^3.1.2"
+          },
+          "dependencies": {
+            "has-flag": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "supports-color": {
+              "version": "3.2.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "has-flag": "^1.0.0"
+              }
+            }
+          }
+        },
+        "istanbul-lib-source-maps": {
+          "version": "1.2.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "debug": "^3.1.0",
+            "istanbul-lib-coverage": "^1.2.0",
+            "mkdirp": "^0.5.1",
+            "rimraf": "^2.6.1",
+            "source-map": "^0.5.3"
+          }
+        },
+        "istanbul-reports": {
+          "version": "1.4.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "handlebars": "^4.0.3"
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        },
+        "lazy-cache": {
+          "version": "1.0.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "lcid": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "invert-kv": "^1.0.0"
+          }
+        },
+        "load-json-file": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          },
+          "dependencies": {
+            "path-exists": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "longest": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "lru-cache": {
+          "version": "4.1.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
+          }
+        },
+        "map-cache": {
+          "version": "0.2.2",
+          "bundled": true,
+          "dev": true
+        },
+        "map-visit": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-visit": "^1.0.0"
+          }
+        },
+        "md5-hex": {
+          "version": "1.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "md5-o-matic": "^0.1.1"
+          }
+        },
+        "md5-o-matic": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "mem": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^1.0.0"
+          }
+        },
+        "merge-source-map": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "source-map": "^0.6.1"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "micromatch": {
+          "version": "3.1.10",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "6.0.2",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "mimic-fn": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true,
+          "dev": true
+        },
+        "mixin-deep": {
+          "version": "1.3.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "for-in": "^1.0.2",
+            "is-extendable": "^1.0.1"
+          },
+          "dependencies": {
+            "is-extendable": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-plain-object": "^2.0.4"
+              }
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "nanomatch": {
+          "version": "1.2.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "fragment-cache": "^0.2.1",
+            "is-odd": "^2.0.0",
+            "is-windows": "^1.0.2",
+            "kind-of": "^6.0.2",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "6.0.2",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "normalize-package-data": {
+          "version": "2.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "^2.1.4",
+            "is-builtin-module": "^1.0.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
+          }
+        },
+        "npm-run-path": {
+          "version": "2.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "path-key": "^2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "object-copy": {
+          "version": "0.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "copy-descriptor": "^0.1.0",
+            "define-property": "^0.2.5",
+            "kind-of": "^3.0.3"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            }
+          }
+        },
+        "object-visit": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "isobject": "^3.0.0"
+          }
+        },
+        "object.pick": {
+          "version": "1.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "isobject": "^3.0.1"
+          }
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "wrappy": "1"
+          }
+        },
+        "optimist": {
+          "version": "0.6.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "~0.0.1",
+            "wordwrap": "~0.0.2"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "os-locale": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "execa": "^0.7.0",
+            "lcid": "^1.0.0",
+            "mem": "^1.1.0"
+          }
+        },
+        "p-finally": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "p-limit": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "parse-json": {
+          "version": "2.2.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.2.0"
+          }
+        },
+        "pascalcase": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "path-parse": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true
+        },
+        "path-type": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "bundled": true,
+          "dev": true
+        },
+        "pinkie": {
+          "version": "2.0.4",
+          "bundled": true,
+          "dev": true
+        },
+        "pinkie-promise": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "pinkie": "^2.0.0"
+          }
+        },
+        "pkg-dir": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "find-up": "^1.0.0"
+          },
+          "dependencies": {
+            "find-up": {
+              "version": "1.1.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "path-exists": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
+              }
+            }
+          }
+        },
+        "posix-character-classes": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "pseudomap": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
+          },
+          "dependencies": {
+            "find-up": {
+              "version": "1.1.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "path-exists": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
+              }
+            }
+          }
+        },
+        "regex-not": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "extend-shallow": "^3.0.2",
+            "safe-regex": "^1.1.0"
+          }
+        },
+        "repeat-element": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "repeat-string": {
+          "version": "1.6.1",
+          "bundled": true,
+          "dev": true
+        },
+        "require-directory": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "require-main-filename": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "resolve-from": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "resolve-url": {
+          "version": "0.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "ret": {
+          "version": "0.1.15",
+          "bundled": true,
+          "dev": true
+        },
+        "right-align": {
+          "version": "0.1.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "align-text": "^0.1.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "glob": "^7.0.5"
+          }
+        },
+        "safe-regex": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ret": "~0.1.10"
+          }
+        },
+        "semver": {
+          "version": "5.5.0",
+          "bundled": true,
+          "dev": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "set-value": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.3",
+            "split-string": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "shebang-command": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^1.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "slide": {
+          "version": "1.1.6",
+          "bundled": true,
+          "dev": true
+        },
+        "snapdragon": {
+          "version": "0.8.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "base": "^0.11.1",
+            "debug": "^2.2.0",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "map-cache": "^0.2.2",
+            "source-map": "^0.5.6",
+            "source-map-resolve": "^0.5.0",
+            "use": "^3.1.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "define-property": {
+              "version": "0.2.5",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "snapdragon-node": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "define-property": "^1.0.0",
+            "isobject": "^3.0.0",
+            "snapdragon-util": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^1.0.0"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
+              }
+            },
+            "kind-of": {
+              "version": "6.0.2",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "snapdragon-util": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.2.0"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "bundled": true,
+          "dev": true
+        },
+        "source-map-resolve": {
+          "version": "0.5.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "atob": "^2.1.1",
+            "decode-uri-component": "^0.2.0",
+            "resolve-url": "^0.2.1",
+            "source-map-url": "^0.4.0",
+            "urix": "^0.1.0"
+          }
+        },
+        "source-map-url": {
+          "version": "0.4.0",
+          "bundled": true,
+          "dev": true
+        },
+        "spawn-wrap": {
+          "version": "1.4.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "foreground-child": "^1.5.6",
+            "mkdirp": "^0.5.0",
+            "os-homedir": "^1.0.1",
+            "rimraf": "^2.6.2",
+            "signal-exit": "^3.0.2",
+            "which": "^1.3.0"
+          }
+        },
+        "spdx-correct": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "spdx-expression-parse": "^3.0.0",
+            "spdx-license-ids": "^3.0.0"
+          }
+        },
+        "spdx-exceptions": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "spdx-expression-parse": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "spdx-exceptions": "^2.1.0",
+            "spdx-license-ids": "^3.0.0"
+          }
+        },
+        "spdx-license-ids": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "split-string": {
+          "version": "3.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "extend-shallow": "^3.0.0"
+          }
+        },
+        "static-extend": {
+          "version": "0.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "define-property": "^0.2.5",
+            "object-copy": "^0.1.0"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            }
+          }
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-utf8": "^0.2.0"
+          }
+        },
+        "strip-eof": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "test-exclude": {
+          "version": "4.2.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "arrify": "^1.0.1",
+            "micromatch": "^3.1.8",
+            "object-assign": "^4.1.0",
+            "read-pkg-up": "^1.0.1",
+            "require-main-filename": "^1.0.1"
+          }
+        },
+        "to-object-path": {
+          "version": "0.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          }
+        },
+        "to-regex": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "regex-not": "^1.0.2",
+            "safe-regex": "^1.1.0"
+          }
+        },
+        "to-regex-range": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1"
+          }
+        },
+        "uglify-js": {
+          "version": "2.8.29",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "source-map": "~0.5.1",
+            "uglify-to-browserify": "~1.0.0",
+            "yargs": "~3.10.0"
+          },
+          "dependencies": {
+            "yargs": {
+              "version": "3.10.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "camelcase": "^1.0.2",
+                "cliui": "^2.1.0",
+                "decamelize": "^1.0.0",
+                "window-size": "0.1.0"
+              }
+            }
+          }
+        },
+        "uglify-to-browserify": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "union-value": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "arr-union": "^3.1.0",
+            "get-value": "^2.0.6",
+            "is-extendable": "^0.1.1",
+            "set-value": "^0.4.3"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            },
+            "set-value": {
+              "version": "0.4.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "extend-shallow": "^2.0.1",
+                "is-extendable": "^0.1.1",
+                "is-plain-object": "^2.0.1",
+                "to-object-path": "^0.3.0"
+              }
+            }
+          }
+        },
+        "unset-value": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "has-value": "^0.3.1",
+            "isobject": "^3.0.0"
+          },
+          "dependencies": {
+            "has-value": {
+              "version": "0.3.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "get-value": "^2.0.3",
+                "has-values": "^0.1.4",
+                "isobject": "^2.0.0"
+              },
+              "dependencies": {
+                "isobject": {
+                  "version": "2.1.0",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "isarray": "1.0.0"
+                  }
+                }
+              }
+            },
+            "has-values": {
+              "version": "0.1.4",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "urix": {
+          "version": "0.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "use": {
+          "version": "3.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "6.0.2",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "validate-npm-package-license": {
+          "version": "3.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "spdx-correct": "^3.0.0",
+            "spdx-expression-parse": "^3.0.0"
+          }
+        },
+        "which": {
+          "version": "1.3.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        },
+        "which-module": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "window-size": {
+          "version": "0.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "wordwrap": {
+          "version": "0.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "wrap-ansi": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "2.1.1",
+              "bundled": true,
+              "dev": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "number-is-nan": "^1.0.0"
+              }
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^2.0.0"
+              }
+            }
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "write-file-atomic": {
+          "version": "1.3.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.11",
+            "imurmurhash": "^0.1.4",
+            "slide": "^1.1.5"
+          }
+        },
+        "y18n": {
+          "version": "3.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "yargs": {
+          "version": "11.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "cliui": "^4.0.0",
+            "decamelize": "^1.1.1",
+            "find-up": "^2.1.0",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^2.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^9.0.2"
+          },
+          "dependencies": {
+            "camelcase": {
+              "version": "4.1.0",
+              "bundled": true,
+              "dev": true
+            },
+            "cliui": {
+              "version": "4.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "string-width": "^2.1.1",
+                "strip-ansi": "^4.0.0",
+                "wrap-ansi": "^2.0.0"
+              }
+            },
+            "yargs-parser": {
+              "version": "9.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "camelcase": "^4.1.0"
+              }
+            }
+          }
+        },
+        "yargs-parser": {
+          "version": "8.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "camelcase": "^4.1.0"
+          },
+          "dependencies": {
+            "camelcase": {
+              "version": "4.1.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        }
       }
     },
     "oauth-sign": {
@@ -509,7 +2970,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "optimist": {
@@ -517,8 +2978,8 @@
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "requires": {
-        "minimist": "0.0.10",
-        "wordwrap": "0.0.3"
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
       }
     },
     "path-is-absolute": {
@@ -526,10 +2987,22 @@
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true
+    },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    },
+    "propagate": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-1.0.0.tgz",
+      "integrity": "sha1-AMLa7t2iDofjeCs0Stuhzd1q1wk=",
+      "dev": true
     },
     "punycode": {
       "version": "1.4.1",
@@ -537,9 +3010,9 @@
       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
     },
     "qs": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
     "querystring": {
       "version": "0.2.0",
@@ -547,32 +3020,30 @@
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
     "request": {
-      "version": "2.85.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
-      "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
+      "version": "2.87.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
+      "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
       "requires": {
-        "aws-sign2": "0.7.0",
-        "aws4": "1.7.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.6",
-        "extend": "3.0.1",
-        "forever-agent": "0.6.1",
-        "form-data": "2.3.2",
-        "har-validator": "5.0.3",
-        "hawk": "6.0.2",
-        "http-signature": "1.2.0",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.18",
-        "oauth-sign": "0.8.2",
-        "performance-now": "2.1.0",
-        "qs": "6.5.1",
-        "safe-buffer": "5.1.1",
-        "stringstream": "0.0.5",
-        "tough-cookie": "2.3.4",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.2.1"
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.6.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.5",
+        "extend": "~3.0.1",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.1",
+        "har-validator": "~5.0.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.17",
+        "oauth-sign": "~0.8.2",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.1",
+        "safe-buffer": "^5.1.1",
+        "tough-cookie": "~2.3.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.1.0"
       }
     },
     "request-promise": {
@@ -580,10 +3051,10 @@
       "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.2.tgz",
       "integrity": "sha1-0epG1lSm7k+O5qT+oQGMIpEZBLQ=",
       "requires": {
-        "bluebird": "3.5.1",
+        "bluebird": "^3.5.0",
         "request-promise-core": "1.1.1",
-        "stealthy-require": "1.1.1",
-        "tough-cookie": "2.3.4"
+        "stealthy-require": "^1.1.0",
+        "tough-cookie": ">=2.3.3"
       }
     },
     "request-promise-core": {
@@ -591,45 +3062,55 @@
       "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
       "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
       "requires": {
-        "lodash": "4.17.5"
+        "lodash": "^4.13.1"
       }
     },
     "safe-buffer": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sax": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
       "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
     },
-    "sntp": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
-      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
-      "requires": {
-        "hoek": "4.2.1"
-      }
+    "semver": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+      "dev": true
     },
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
     "sshpk": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
-      "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
+      "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
       "requires": {
-        "asn1": "0.2.3",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "tweetnacl": "0.14.5"
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
       }
     },
     "stealthy-require": {
@@ -642,30 +3123,46 @@
       "resolved": "https://registry.npmjs.org/string-score/-/string-score-1.0.1.tgz",
       "integrity": "sha1-ofMZEHBaEZM3pQbKcYsehd8S3Vg="
     },
-    "stringstream": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+    "supports-color": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+      "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
     },
     "sylvester": {
       "version": "0.0.21",
       "resolved": "https://registry.npmjs.org/sylvester/-/sylvester-0.0.21.tgz",
       "integrity": "sha1-KYexzivS84sNzio0OIiEv6RADqc="
     },
+    "to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "dev": true
+    },
     "tough-cookie": {
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
       "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
       "requires": {
-        "punycode": "1.4.1"
+        "punycode": "^1.4.1"
       }
+    },
+    "trim-right": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+      "dev": true
     },
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.0.1"
       }
     },
     "tweetnacl": {
@@ -674,13 +3171,19 @@
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "optional": true
     },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
+    },
     "uglify-js": {
       "version": "3.3.21",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.21.tgz",
       "integrity": "sha512-uy82472lH8tshK3jS3c5IFb5MmNKd/5qyBd0ih8sM42L3jWvxnE339U9gZU1zufnLVs98Stib9twq8dLm2XYCA==",
       "requires": {
-        "commander": "2.15.1",
-        "source-map": "0.6.1"
+        "commander": "~2.15.0",
+        "source-map": "~0.6.1"
       }
     },
     "underscore": {
@@ -714,9 +3217,65 @@
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
-        "assert-plus": "1.0.0",
+        "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
+        "extsprintf": "^1.2.0"
+      }
+    },
+    "virtual-alexa": {
+      "version": "0.6.9",
+      "resolved": "https://registry.npmjs.org/virtual-alexa/-/virtual-alexa-0.6.9.tgz",
+      "integrity": "sha512-f7vFVJ1fiJPh7GZGSpx2iQMqDvp/lWJ/44Mx/QXzSHWP4NtAR8NWF9k54BKlSUpbtyI5NbIMPk5TTyzUr2x55A==",
+      "dev": true,
+      "requires": {
+        "aws-sdk": "^2.246.1",
+        "lodash": "^4.17.10",
+        "nock": "^9.2.6",
+        "uuid": "^3.2.1",
+        "virtual-core": "0.0.12"
+      },
+      "dependencies": {
+        "aws-sdk": {
+          "version": "2.262.1",
+          "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.262.1.tgz",
+          "integrity": "sha512-SF7Zugvb5mQyvdBU80LIS+tIbBwl8G3HTcwgqA6d0p8qouC/mHpTprpLjhtmwJmFILWeBzjUt76fPw1XZXWtrw==",
+          "dev": true,
+          "requires": {
+            "buffer": "4.9.1",
+            "events": "1.1.1",
+            "ieee754": "1.1.8",
+            "jmespath": "0.15.0",
+            "querystring": "0.2.0",
+            "sax": "1.2.1",
+            "url": "0.10.3",
+            "uuid": "3.1.0",
+            "xml2js": "0.4.17"
+          },
+          "dependencies": {
+            "uuid": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+              "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
+              "dev": true
+            }
+          }
+        },
+        "lodash": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+          "dev": true
+        }
+      }
+    },
+    "virtual-core": {
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/virtual-core/-/virtual-core-0.0.12.tgz",
+      "integrity": "sha1-YxreHH8WiZK44jUyWB6QFn+qGdQ=",
+      "dev": true,
+      "requires": {
+        "@types/uuid": "^3.4.3",
+        "uuid": "^3.2.1"
       }
     },
     "webworker-threads": {
@@ -724,8 +3283,8 @@
       "resolved": "https://registry.npmjs.org/webworker-threads/-/webworker-threads-0.7.13.tgz",
       "integrity": "sha1-yEsYtrokElu503NC5E3rgVFi+4M=",
       "requires": {
-        "bindings": "1.3.0",
-        "nan": "2.10.0"
+        "bindings": "^1.2.1",
+        "nan": "^2.4.0"
       }
     },
     "wordwrap": {
@@ -743,8 +3302,8 @@
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
       "integrity": "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg=",
       "requires": {
-        "sax": "1.2.1",
-        "xmlbuilder": "4.2.1"
+        "sax": ">=0.6.0",
+        "xmlbuilder": "^4.1.0"
       }
     },
     "xmlbuilder": {
@@ -752,7 +3311,7 @@
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
       "integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=",
       "requires": {
-        "lodash": "4.17.5"
+        "lodash": "^4.0.0"
       }
     }
   }

--- a/lambda/custom/package-lock.json
+++ b/lambda/custom/package-lock.json
@@ -4,146 +4,16 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@babel/code-frame": {
-      "version": "7.0.0-beta.49",
-      "resolved":
-        "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.49.tgz",
-      "integrity": "sha1-vs2AVIJzREDJ0TfkbXc0DmTX9Rs=",
-      "dev": true,
-      "requires": {
-        "@babel/highlight": "7.0.0-beta.49"
-      }
-    },
-    "@babel/generator": {
-      "version": "7.0.0-beta.49",
-      "resolved":
-        "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.49.tgz",
-      "integrity": "sha1-6c/9qROZaszseTu8JauRvBnQv3o=",
-      "dev": true,
-      "requires": {
-        "@babel/types": "7.0.0-beta.49",
-        "jsesc": "^2.5.1",
-        "lodash": "^4.17.5",
-        "source-map": "^0.5.0",
-        "trim-right": "^1.0.1"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.5.7",
-          "resolved":
-            "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
-        }
-      }
-    },
-    "@babel/helper-function-name": {
-      "version": "7.0.0-beta.49",
-      "resolved":
-        "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.49.tgz",
-      "integrity": "sha1-olwRGbnwNSeGcBJuAiXAMEHI3jI=",
-      "dev": true,
-      "requires": {
-        "@babel/helper-get-function-arity": "7.0.0-beta.49",
-        "@babel/template": "7.0.0-beta.49",
-        "@babel/types": "7.0.0-beta.49"
-      }
-    },
-    "@babel/helper-get-function-arity": {
-      "version": "7.0.0-beta.49",
-      "resolved":
-        "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.49.tgz",
-      "integrity": "sha1-z1Aj8y0q2S0Ic3STnOwJUby1FEE=",
-      "dev": true,
-      "requires": {
-        "@babel/types": "7.0.0-beta.49"
-      }
-    },
-    "@babel/helper-split-export-declaration": {
-      "version": "7.0.0-beta.49",
-      "resolved":
-        "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.49.tgz",
-      "integrity": "sha1-QNeO2glo0BGxxShm5XRs+yPldUg=",
-      "dev": true,
-      "requires": {
-        "@babel/types": "7.0.0-beta.49"
-      }
-    },
-    "@babel/highlight": {
-      "version": "7.0.0-beta.49",
-      "resolved":
-        "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.49.tgz",
-      "integrity": "sha1-lr3GtD4TSCASumaRsQGEktOWIsw=",
-      "dev": true,
-      "requires": {
-        "chalk": "^2.0.0",
-        "esutils": "^2.0.2",
-        "js-tokens": "^3.0.0"
-      }
-    },
-    "@babel/parser": {
-      "version": "7.0.0-beta.49",
-      "resolved":
-        "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.49.tgz",
-      "integrity": "sha1-lE0MW6KBK7FZ7b0iZ0Ov0mUXm9w=",
-      "dev": true
-    },
-    "@babel/template": {
-      "version": "7.0.0-beta.49",
-      "resolved":
-        "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.49.tgz",
-      "integrity": "sha1-44q+ghfLl5P0YaUwbXrXRdg+HSc=",
-      "dev": true,
-      "requires": {
-        "@babel/code-frame": "7.0.0-beta.49",
-        "@babel/parser": "7.0.0-beta.49",
-        "@babel/types": "7.0.0-beta.49",
-        "lodash": "^4.17.5"
-      }
-    },
-    "@babel/traverse": {
-      "version": "7.0.0-beta.49",
-      "resolved":
-        "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.49.tgz",
-      "integrity": "sha1-TypzaCoYM07WYl0QCo0nMZ98LWg=",
-      "dev": true,
-      "requires": {
-        "@babel/code-frame": "7.0.0-beta.49",
-        "@babel/generator": "7.0.0-beta.49",
-        "@babel/helper-function-name": "7.0.0-beta.49",
-        "@babel/helper-split-export-declaration": "7.0.0-beta.49",
-        "@babel/parser": "7.0.0-beta.49",
-        "@babel/types": "7.0.0-beta.49",
-        "debug": "^3.1.0",
-        "globals": "^11.1.0",
-        "invariant": "^2.2.0",
-        "lodash": "^4.17.5"
-      }
-    },
-    "@babel/types": {
-      "version": "7.0.0-beta.49",
-      "resolved":
-        "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.49.tgz",
-      "integrity": "sha1-t+Oxw/TUz+Eb34yJ8e/V4WF7h6Y=",
-      "dev": true,
-      "requires": {
-        "esutils": "^2.0.2",
-        "lodash": "^4.17.5",
-        "to-fast-properties": "^2.0.0"
-      }
-    },
     "@types/node": {
-      "version": "10.3.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.3.4.tgz",
-      "integrity":
-        "sha512-YMLlzdeNnAyLrQew39IFRkMacAR5BqKGIEei9ZjdHsIZtv+ZWKYTu1i7QJhetxQ9ReXx8w5f+cixdHZG3zgMQA==",
+      "version": "10.5.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.5.1.tgz",
+      "integrity": "sha512-AFLl1IALIuyt6oK4AYZsgWVJ/5rnyzQWud7IebaZWWV3YmgtPZkQmYio9R5Ze/2pdd7XfqF5bP+hWS11mAKoOQ==",
       "dev": true
     },
     "@types/uuid": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.3.tgz",
-      "integrity":
-        "sha512-5fRLCYhLtDb3hMWqQyH10qtF+Ud2JnNCXTCZ+9ktNdCcgslcuXkDTkFcJNk++MT29yDntDnlF1+jD+uVGumsbw==",
+      "integrity": "sha512-5fRLCYhLtDb3hMWqQyH10qtF+Ud2JnNCXTCZ+9ktNdCcgslcuXkDTkFcJNk++MT29yDntDnlF1+jD+uVGumsbw==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -160,6 +30,32 @@
         "json-schema-traverse": "^0.3.0"
       }
     },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^1.9.0"
+      },
+      "dependencies": {
+        "color-convert": {
+          "version": "1.9.2",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.2.tgz",
+          "integrity": "sha512-3NUJZdhMhcdPn8vJ9v2UQJoH0qqoGUkYTgFEPZaPjEtwmmKUfNV46zZmgB2M5M4DCEQHMaCfWHCxiBflLm04Tg==",
+          "dev": true,
+          "requires": {
+            "color-name": "1.1.1"
+          }
+        },
+        "color-name": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
+          "integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok=",
+          "dev": true
+        }
+      }
+    },
     "apparatus": {
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/apparatus/-/apparatus-0.0.9.tgz",
@@ -171,22 +67,47 @@
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity":
-        "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
       }
     },
+    "ask-sdk": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/ask-sdk/-/ask-sdk-2.0.7.tgz",
+      "integrity": "sha512-fJDjDv1BqTvfiwHKOgPYuQbi0HCfe320Po1S6qqhdgHN/ZHuolHRYIEe8i3O1sk/qObCsrwOD9xh0l10E48Spw==",
+      "requires": {
+        "ask-sdk-core": "^2.0.7",
+        "ask-sdk-dynamodb-persistence-adapter": "^2.0.7",
+        "ask-sdk-model": "^1.0.0"
+      }
+    },
+    "ask-sdk-core": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/ask-sdk-core/-/ask-sdk-core-2.0.7.tgz",
+      "integrity": "sha512-L0YoF7ls0iUoo/WYDYj7uDjAFThYZSDjzF8YvLHIEZyzKVgrNNqxetRorUB+odDoctPWW7RV1xcep8F4p7c1jg=="
+    },
+    "ask-sdk-dynamodb-persistence-adapter": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/ask-sdk-dynamodb-persistence-adapter/-/ask-sdk-dynamodb-persistence-adapter-2.0.7.tgz",
+      "integrity": "sha512-RHIOOAfsIwZy7hUtENPF12l1NldB8+rRZ3Jk4I9efpFFZSmXOM510Qho3Lt3OZCH9qTDRp1QWrQvn3ki7fdM8A==",
+      "requires": {
+        "aws-sdk": "^2.163.0"
+      }
+    },
+    "ask-sdk-model": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/ask-sdk-model/-/ask-sdk-model-1.3.1.tgz",
+      "integrity": "sha512-ZDcmJ8sDRAzfIPz5WhRpy8HJ8SheBOyjoeHtYIcoVO6ZQEgxXtZ11GJGg8FhRDfwwIWj5Ma8G6m7OCgo4nuJDA=="
+    },
     "ask-sdk-v1adapter": {
       "version": "2.0.7",
-      "resolved":
-        "https://registry.npmjs.org/ask-sdk-v1adapter/-/ask-sdk-v1adapter-2.0.7.tgz",
-      "integrity":
-        "sha512-XOhCsLTg0BSVX958Nw+AwxgZpPwcU2MlB8VvEHqUrXQ5F3jahKCQvfSwICJtNApj0hhRx5rC2JFHd6tXwxpgRg==",
+      "resolved": "https://registry.npmjs.org/ask-sdk-v1adapter/-/ask-sdk-v1adapter-2.0.7.tgz",
+      "integrity": "sha1-DGmFtvowC64ERodbOkfVWMZS3t0=",
       "requires": {
-        "i18next": "3.5.2",
-        "i18next-sprintf-postprocessor": "0.2.2"
+        "i18next": "^3.4.1",
+        "i18next-sprintf-postprocessor": "^0.2.2"
       }
     },
     "asn1": {
@@ -196,24 +117,27 @@
     },
     "assert-plus": {
       "version": "1.0.0",
-      "resolved":
-        "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+    },
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
     },
     "async": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
-      "integrity":
-        "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+      "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
       "requires": {
-        "lodash": "4.17.10"
+        "lodash": "^4.17.10"
       },
       "dependencies": {
         "lodash": {
           "version": "4.17.10",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-          "integrity":
-            "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
         }
       }
     },
@@ -221,6 +145,29 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "aws-sdk": {
+      "version": "2.266.1",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.266.1.tgz",
+      "integrity": "sha512-b8lisloCETh0Fx0il540i+Hbgf3hyegQ6ezoJFggfc1HIbqzvIjVJYJhOsYl1fL1o+iMUaVU4ZH8cSyoMFR2Tw==",
+      "requires": {
+        "buffer": "4.9.1",
+        "events": "1.1.1",
+        "ieee754": "1.1.8",
+        "jmespath": "0.15.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.1.0",
+        "xml2js": "0.4.17"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+          "integrity": "sha1-PdPT55Crwk17DToDT/q6vijrvAQ="
+        }
+      }
     },
     "aws-sign2": {
       "version": "0.7.0",
@@ -230,19 +177,21 @@
     "aws4": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
-      "integrity":
-        "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
+      "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
     },
     "balanced-match": {
       "version": "1.0.0",
-      "resolved":
-        "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "base64-js": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
+      "integrity": "sha1-yrHmEY8FEJXli1KBrqjBzSK/wOM="
     },
     "bcrypt-pbkdf": {
       "version": "1.0.1",
-      "resolved":
-        "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
       "optional": true,
       "requires": {
@@ -252,24 +201,36 @@
     "bindings": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
-      "integrity":
-        "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw=="
+      "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw=="
     },
     "bluebird": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-      "integrity":
-        "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
     },
     "brace-expansion": {
       "version": "1.1.11",
-      "resolved":
-        "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity":
-        "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
+    },
+    "buffer": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+      "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
       }
     },
     "caseless": {
@@ -294,8 +255,7 @@
     "chalk": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-      "integrity":
-        "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+      "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
       "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
@@ -305,8 +265,7 @@
     },
     "check-error": {
       "version": "1.0.2",
-      "resolved":
-        "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
       "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
       "dev": true
     },
@@ -328,57 +287,50 @@
       "resolved": "https://registry.npmjs.org/color/-/color-0.8.0.tgz",
       "integrity": "sha1-iQwHw/1OZJU3Y4kRz2keVFi2/KU=",
       "requires": {
-        "color-convert": "0.5.3",
-        "color-string": "0.3.0"
+        "color-convert": "^0.5.0",
+        "color-string": "^0.3.0"
       }
     },
     "color-convert": {
       "version": "0.5.3",
-      "resolved":
-        "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
       "integrity": "sha1-vbbGnOZg+t/+CwAHzER+G59ygr0="
     },
     "color-name": {
       "version": "1.1.3",
-      "resolved":
-        "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "color-string": {
       "version": "0.3.0",
-      "resolved":
-        "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
       "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
       "requires": {
-        "color-name": "1.1.3"
+        "color-name": "^1.0.0"
       }
     },
     "colornames": {
       "version": "0.0.2",
-      "resolved":
-        "https://registry.npmjs.org/colornames/-/colornames-0.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/colornames/-/colornames-0.0.2.tgz",
       "integrity": "sha1-2BH9bIT1kClJmorEQ2ICk1uSvjE="
     },
     "colors": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.2.1.tgz",
-      "integrity":
-        "sha512-s8+wktIuDSLffCywiwSxQOMqtPxML11a/dtHE17tMn4B1MSWw/C22EKf7M2KGUBcDaVFEGT+S8N02geDXeuNKg=="
+      "integrity": "sha512-s8+wktIuDSLffCywiwSxQOMqtPxML11a/dtHE17tMn4B1MSWw/C22EKf7M2KGUBcDaVFEGT+S8N02geDXeuNKg=="
     },
     "colorspace": {
       "version": "1.0.1",
-      "resolved":
-        "https://registry.npmjs.org/colorspace/-/colorspace-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.0.1.tgz",
       "integrity": "sha1-yZx5btMRKLmHalLh7l7gOkpxl0k=",
       "requires": {
-        "color": "0.8.0",
-        "text-hex": "0.0.0"
+        "color": "0.8.x",
+        "text-hex": "0.0.x"
       }
     },
     "combined-stream": {
       "version": "1.0.6",
-      "resolved":
-        "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "requires": {
         "delayed-stream": "~1.0.0"
@@ -387,39 +339,35 @@
     "commander": {
       "version": "2.15.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-      "integrity":
-        "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
+      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
     },
     "concat-map": {
       "version": "0.0.1",
-      "resolved":
-        "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "core-util-is": {
       "version": "1.0.2",
-      "resolved":
-        "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "coveralls": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.1.tgz",
-      "integrity":
-        "sha512-FAzXwiDOYLGDWH+zgoIA+8GbWv50hlx+kpEJyvzLKOdnIBv9uWoVl4DhqGgyUHpiRjAlF8KYZSipWXYtllWH6Q==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.2.tgz",
+      "integrity": "sha512-Tv0LKe/MkBOilH2v7WBiTBdudg2ChfGbdXafc/s330djpF3zKOmuehTeRwjXWc7pzfj9FrDUTA7tEx6Div8NFw==",
       "dev": true,
       "requires": {
-        "js-yaml": "^3.6.1",
+        "growl": "~> 1.10.0",
+        "js-yaml": "^3.11.0",
         "lcov-parse": "^0.0.10",
-        "log-driver": "^1.2.5",
+        "log-driver": "^1.2.7",
         "minimist": "^1.2.0",
-        "request": "^2.79.0"
+        "request": "^2.85.0"
       },
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved":
-            "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -436,18 +384,24 @@
     "debug": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity":
-        "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
       "dev": true,
       "requires": {
         "ms": "2.0.0"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
       }
     },
     "deep-eql": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-      "integrity":
-        "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
       "dev": true,
       "requires": {
         "type-detect": "^4.0.0"
@@ -455,27 +409,30 @@
     },
     "deep-equal": {
       "version": "1.0.1",
-      "resolved":
-        "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
       "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
       "dev": true
     },
     "delayed-stream": {
       "version": "1.0.0",
-      "resolved":
-        "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "diagnostics": {
       "version": "1.1.0",
-      "resolved":
-        "https://registry.npmjs.org/diagnostics/-/diagnostics-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/diagnostics/-/diagnostics-1.1.0.tgz",
       "integrity": "sha1-4QkJALSVI+hSe+IPCBJ1IF8q42o=",
       "requires": {
-        "colorspace": "1.0.1",
-        "enabled": "1.0.2",
-        "kuler": "0.0.0"
+        "colorspace": "1.0.x",
+        "enabled": "1.0.x",
+        "kuler": "0.0.x"
       }
+    },
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true
     },
     "ecc-jsbn": {
       "version": "0.1.1",
@@ -491,15 +448,36 @@
       "resolved": "https://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
       "integrity": "sha1-ll9lE9LC0cX0ZStkouM5ZGf8L5M=",
       "requires": {
-        "env-variable": "0.0.4"
+        "env-variable": "0.0.x"
       }
     },
     "env-variable": {
       "version": "0.0.4",
-      "resolved":
-        "https://registry.npmjs.org/env-variable/-/env-variable-0.0.4.tgz",
-      "integrity":
-        "sha512-+jpGxSWG4vr6gVxUHOc4p+ilPnql7NzZxOZBxNldsKGjCF+97df3CbuX7XMaDa5oAVkKQj4rKp38rYdC4VcpDg=="
+      "resolved": "https://registry.npmjs.org/env-variable/-/env-variable-0.0.4.tgz",
+      "integrity": "sha512-+jpGxSWG4vr6gVxUHOc4p+ilPnql7NzZxOZBxNldsKGjCF+97df3CbuX7XMaDa5oAVkKQj4rKp38rYdC4VcpDg=="
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "esprima": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true
+    },
+    "events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
     },
     "extend": {
       "version": "3.0.1",
@@ -508,39 +486,32 @@
     },
     "extsprintf": {
       "version": "1.3.0",
-      "resolved":
-        "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "fast-deep-equal": {
       "version": "1.1.0",
-      "resolved":
-        "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
       "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
-      "resolved":
-        "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "fast-safe-stringify": {
       "version": "2.0.4",
-      "resolved":
-        "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.4.tgz",
-      "integrity":
-        "sha512-mNlGUdKOeGNleyrmgbKYtbnCr9KZkZXU7eM89JRo8vY10f7Ul1Fbj07hUBW3N4fC0xM+fmfFfa2zM7mIizhpNQ=="
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.4.tgz",
+      "integrity": "sha512-mNlGUdKOeGNleyrmgbKYtbnCr9KZkZXU7eM89JRo8vY10f7Ul1Fbj07hUBW3N4fC0xM+fmfFfa2zM7mIizhpNQ=="
     },
     "fecha": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz",
-      "integrity":
-        "sha512-lUGBnIamTAwk4znq5BcqsDaxSmZ9nDVJaij6NvRt/Tg4R69gERA+otPKbS86ROw9nxVMw2/mp1fnaiWqbs6Sdg=="
+      "integrity": "sha512-lUGBnIamTAwk4znq5BcqsDaxSmZ9nDVJaij6NvRt/Tg4R69gERA+otPKbS86ROw9nxVMw2/mp1fnaiWqbs6Sdg=="
     },
     "forever-agent": {
       "version": "0.6.1",
-      "resolved":
-        "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
@@ -555,8 +526,7 @@
     },
     "fs.realpath": {
       "version": "1.0.0",
-      "resolved":
-        "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fuse": {
@@ -578,8 +548,7 @@
     },
     "get-func-name": {
       "version": "2.0.0",
-      "resolved":
-        "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
     },
@@ -594,8 +563,7 @@
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity":
-        "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -607,10 +575,8 @@
       "dependencies": {
         "minimatch": {
           "version": "3.0.4",
-          "resolved":
-            "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity":
-            "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -620,27 +586,23 @@
     "globals": {
       "version": "11.7.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
-      "integrity":
-        "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg==",
+      "integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg==",
       "dev": true
     },
     "growl": {
       "version": "1.10.5",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-      "integrity":
-        "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
       "dev": true
     },
     "har-schema": {
       "version": "2.0.0",
-      "resolved":
-        "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
       "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
     },
     "har-validator": {
       "version": "5.0.3",
-      "resolved":
-        "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "requires": {
         "ajv": "^5.1.0",
@@ -661,8 +623,7 @@
     },
     "http-signature": {
       "version": "1.2.0",
-      "resolved":
-        "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "requires": {
         "assert-plus": "^1.0.0",
@@ -677,9 +638,13 @@
     },
     "i18next-sprintf-postprocessor": {
       "version": "0.2.2",
-      "resolved":
-        "https://registry.npmjs.org/i18next-sprintf-postprocessor/-/i18next-sprintf-postprocessor-0.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/i18next-sprintf-postprocessor/-/i18next-sprintf-postprocessor-0.2.2.tgz",
       "integrity": "sha1-LkCfEENXk4Jpi2otpwzapVHWfqQ="
+    },
+    "ieee754": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
+      "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
     },
     "inflight": {
       "version": "1.0.6",
@@ -695,6 +660,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
+    "invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
@@ -702,8 +676,7 @@
     },
     "is-typedarray": {
       "version": "1.0.0",
-      "resolved":
-        "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "isarray": {
@@ -715,6 +688,165 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "istanbul-lib-coverage": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.0.tgz",
+      "integrity": "sha512-yMSw5xLIbdaxiVXHk3amfNM2WeBxLrwH/BCyZ9HvA/fylwziAIJOG2rKqWyLqEJqwKT725vxxqidv+SyynnGAA==",
+      "dev": true
+    },
+    "istanbul-lib-instrument": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-2.3.0.tgz",
+      "integrity": "sha512-Ie1LGWJVCFDDJKKH4g1ffpFcZTEXEd6ay5l9fE8539y4qPErJnzo4psnGzDH92tcKvdUDdbxrKySYIbt6zB9hw==",
+      "dev": true,
+      "requires": {
+        "@babel/generator": "7.0.0-beta.51",
+        "@babel/parser": "7.0.0-beta.51",
+        "@babel/template": "7.0.0-beta.51",
+        "@babel/traverse": "7.0.0-beta.51",
+        "@babel/types": "7.0.0-beta.51",
+        "istanbul-lib-coverage": "^2.0.0",
+        "semver": "^5.5.0"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.0.0-beta.51",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.51.tgz",
+          "integrity": "sha1-vXHZsZKvl435FYKdOdQJRFZDmgw=",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "7.0.0-beta.51"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.0.0-beta.51",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.51.tgz",
+          "integrity": "sha1-bHV1/952HQdIXgS67cA5LG2eMPY=",
+          "dev": true,
+          "requires": {
+            "@babel/types": "7.0.0-beta.51",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.5",
+            "source-map": "^0.5.0",
+            "trim-right": "^1.0.1"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.0.0-beta.51",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.51.tgz",
+          "integrity": "sha1-IbSHSiJ8+Z7K/MMKkDAtpaJkBWE=",
+          "dev": true,
+          "requires": {
+            "@babel/helper-get-function-arity": "7.0.0-beta.51",
+            "@babel/template": "7.0.0-beta.51",
+            "@babel/types": "7.0.0-beta.51"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.0.0-beta.51",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.51.tgz",
+          "integrity": "sha1-MoGy0EWvlcFyzpGyCCXYXqRnZBE=",
+          "dev": true,
+          "requires": {
+            "@babel/types": "7.0.0-beta.51"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.0.0-beta.51",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.51.tgz",
+          "integrity": "sha1-imw/ZsTSZTUvwHdIT59ugKUauXg=",
+          "dev": true,
+          "requires": {
+            "@babel/types": "7.0.0-beta.51"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.0.0-beta.51",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.51.tgz",
+          "integrity": "sha1-6IRK4loVlcz9QriWI7Q3bKBtIl0=",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.0.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.0.0-beta.51",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.51.tgz",
+          "integrity": "sha1-J87C30Cd9gr1gnDtj2qlVAnqhvY=",
+          "dev": true
+        },
+        "@babel/template": {
+          "version": "7.0.0-beta.51",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.51.tgz",
+          "integrity": "sha1-lgKkCuvPNXrpZ34lMu9fyBD1+/8=",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "7.0.0-beta.51",
+            "@babel/parser": "7.0.0-beta.51",
+            "@babel/types": "7.0.0-beta.51",
+            "lodash": "^4.17.5"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.0.0-beta.51",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.51.tgz",
+          "integrity": "sha1-mB2vLOw0emIx06odnhgDsDqqpKg=",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "7.0.0-beta.51",
+            "@babel/generator": "7.0.0-beta.51",
+            "@babel/helper-function-name": "7.0.0-beta.51",
+            "@babel/helper-split-export-declaration": "7.0.0-beta.51",
+            "@babel/parser": "7.0.0-beta.51",
+            "@babel/types": "7.0.0-beta.51",
+            "debug": "^3.1.0",
+            "globals": "^11.1.0",
+            "invariant": "^2.2.0",
+            "lodash": "^4.17.5"
+          }
+        },
+        "@babel/types": {
+          "version": "7.0.0-beta.51",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.51.tgz",
+          "integrity": "sha1-2AK3tUO1g2x3iqaReXq/APPZfqk=",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.5",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
+    },
+    "js-tokens": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
+      "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
     },
     "jsbn": {
       "version": "0.1.1",
@@ -739,20 +871,17 @@
     },
     "json-schema": {
       "version": "0.2.3",
-      "resolved":
-        "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
     "json-schema-traverse": {
       "version": "0.3.1",
-      "resolved":
-        "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
       "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
     },
     "json-stringify-safe": {
       "version": "5.0.1",
-      "resolved":
-        "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "jsprim": {
@@ -774,23 +903,42 @@
         "colornames": "0.0.2"
       }
     },
+    "lcov-parse": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
+      "integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=",
+      "dev": true
+    },
     "lodash": {
       "version": "4.17.5",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-      "integrity":
-        "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+    },
+    "log-driver": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
+      "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
+      "dev": true
     },
     "logform": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/logform/-/logform-1.9.1.tgz",
-      "integrity":
-        "sha512-ZHrZE8VSf7K3xKxJiQ1aoTBp2yK+cEbFcgarsjzI3nt3nE/3O0heNSppoOQMUJVMZo/xiVwCxiXIabaZApsKNQ==",
+      "integrity": "sha512-ZHrZE8VSf7K3xKxJiQ1aoTBp2yK+cEbFcgarsjzI3nt3nE/3O0heNSppoOQMUJVMZo/xiVwCxiXIabaZApsKNQ==",
       "requires": {
-        "colors": "1.2.1",
-        "fast-safe-stringify": "2.0.4",
-        "fecha": "2.3.3",
-        "ms": "2.1.1",
-        "triple-beam": "1.3.0"
+        "colors": "^1.2.1",
+        "fast-safe-stringify": "^2.0.4",
+        "fecha": "^2.3.3",
+        "ms": "^2.1.1",
+        "triple-beam": "^1.2.0"
+      }
+    },
+    "loose-envify": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+      "dev": true,
+      "requires": {
+        "js-tokens": "^3.0.0"
       }
     },
     "lru-cache": {
@@ -801,15 +949,12 @@
     "mime-db": {
       "version": "1.33.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
-      "integrity":
-        "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
+      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
     },
     "mime-types": {
       "version": "2.1.18",
-      "resolved":
-        "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
-      "integrity":
-        "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+      "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
       "requires": {
         "mime-db": "~1.33.0"
       }
@@ -827,17 +972,68 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
       "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
     },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        }
+      }
+    },
+    "mocha": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
+      "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.1",
+        "commander": "2.15.1",
+        "debug": "3.1.0",
+        "diff": "3.5.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "growl": "1.10.5",
+        "he": "1.1.1",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "supports-color": "5.4.0"
+      },
+      "dependencies": {
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        }
+      }
+    },
+    "mocha-lcov-reporter": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/mocha-lcov-reporter/-/mocha-lcov-reporter-1.3.0.tgz",
+      "integrity": "sha1-Rpve9PivyaEWBW8HnfYYLQr7A4Q=",
+      "dev": true
+    },
     "ms": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-      "integrity":
-        "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
     },
     "nan": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-      "integrity":
-        "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
+      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
     },
     "natural": {
       "version": "0.5.1",
@@ -851,10 +1047,9 @@
       }
     },
     "nock": {
-      "version": "9.3.3",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-9.3.3.tgz",
-      "integrity":
-        "sha512-FBgnx25er2ly7KBr0Est5F0z5g+lnyr6a72vZI1KMi7nTL4ojU6XpFhlrfw6CXRdnT2FA5i8exHiT1uVNUM1qA==",
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-9.4.1.tgz",
+      "integrity": "sha512-VJ/02wdCfqJP8syNI5q2CFbejAqN0NLEPvA/nNcGXn3U8GoivtmICmTK3BOqLbfJyaDCXF0Jq+lkQUXBJ1ZMtw==",
       "dev": true,
       "requires": {
         "chai": "^4.1.2",
@@ -2923,8 +3118,7 @@
     },
     "oauth-sign": {
       "version": "0.8.2",
-      "resolved":
-        "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
       "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
     },
     "once": {
@@ -2951,8 +3145,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved":
-        "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "pathval": {
@@ -2963,16 +3156,19 @@
     },
     "performance-now": {
       "version": "2.1.0",
-      "resolved":
-        "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "process-nextick-args": {
       "version": "2.0.0",
-      "resolved":
-        "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity":
-        "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+    },
+    "propagate": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-1.0.0.tgz",
+      "integrity": "sha1-AMLa7t2iDofjeCs0Stuhzd1q1wk=",
+      "dev": true
     },
     "punycode": {
       "version": "1.4.1",
@@ -2982,30 +3178,31 @@
     "qs": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity":
-        "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+    },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved":
-        "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-      "integrity":
-        "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "2.0.0",
-        "safe-buffer": "5.1.1",
-        "string_decoder": "1.1.1",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       }
     },
     "request": {
       "version": "2.87.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
-      "integrity":
-        "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
+      "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
       "requires": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.6.0",
@@ -3031,8 +3228,7 @@
     },
     "request-promise": {
       "version": "4.2.2",
-      "resolved":
-        "https://registry.npmjs.org/request-promise/-/request-promise-4.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.2.tgz",
       "integrity": "sha1-0epG1lSm7k+O5qT+oQGMIpEZBLQ=",
       "requires": {
         "bluebird": "^3.5.0",
@@ -3043,8 +3239,7 @@
     },
     "request-promise-core": {
       "version": "1.1.1",
-      "resolved":
-        "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
       "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
       "requires": {
         "lodash": "^4.13.1"
@@ -3052,38 +3247,33 @@
     },
     "safe-buffer": {
       "version": "5.1.2",
-      "resolved":
-        "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity":
-        "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "safer-buffer": {
       "version": "2.1.2",
-      "resolved":
-        "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity":
-        "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
-    "sntp": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
-      "integrity":
-        "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
-      "requires": {
-        "hoek": "4.2.1"
-      }
+    "sax": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
+    },
+    "semver": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+      "dev": true
     },
     "source-map": {
       "version": "0.6.1",
-      "resolved":
-        "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity":
-        "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved":
-        "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
@@ -3105,37 +3295,35 @@
     },
     "stack-trace": {
       "version": "0.0.10",
-      "resolved":
-        "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
       "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
     },
     "stealthy-require": {
       "version": "1.1.1",
-      "resolved":
-        "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
     },
     "string-score": {
       "version": "1.0.1",
-      "resolved":
-        "https://registry.npmjs.org/string-score/-/string-score-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/string-score/-/string-score-1.0.1.tgz",
       "integrity": "sha1-ofMZEHBaEZM3pQbKcYsehd8S3Vg="
     },
     "string_decoder": {
       "version": "1.1.1",
-      "resolved":
-        "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity":
-        "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "~5.1.0"
       }
     },
-    "stringstream": {
-      "version": "0.0.5",
-      "resolved":
-        "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+    "supports-color": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+      "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
     },
     "sylvester": {
       "version": "0.0.21",
@@ -3147,27 +3335,34 @@
       "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-0.0.0.tgz",
       "integrity": "sha1-V4+8haapJjbkLdF7QdAhjM6esrM="
     },
+    "to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "dev": true
+    },
     "tough-cookie": {
       "version": "2.3.4",
-      "resolved":
-        "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
-      "integrity":
-        "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+      "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
       "requires": {
         "punycode": "^1.4.1"
       }
     },
+    "trim-right": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+      "dev": true
+    },
     "triple-beam": {
       "version": "1.3.0",
-      "resolved":
-        "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
-      "integrity":
-        "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
+      "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
     },
     "tunnel-agent": {
       "version": "0.6.0",
-      "resolved":
-        "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
         "safe-buffer": "^5.0.1"
@@ -3181,17 +3376,14 @@
     },
     "type-detect": {
       "version": "4.0.8",
-      "resolved":
-        "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity":
-        "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true
     },
     "uglify-js": {
       "version": "3.3.21",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.21.tgz",
-      "integrity":
-        "sha512-uy82472lH8tshK3jS3c5IFb5MmNKd/5qyBd0ih8sM42L3jWvxnE339U9gZU1zufnLVs98Stib9twq8dLm2XYCA==",
+      "integrity": "sha512-uy82472lH8tshK3jS3c5IFb5MmNKd/5qyBd0ih8sM42L3jWvxnE339U9gZU1zufnLVs98Stib9twq8dLm2XYCA==",
       "requires": {
         "commander": "~2.15.0",
         "source-map": "~0.6.1"
@@ -3199,21 +3391,34 @@
     },
     "underscore": {
       "version": "1.8.3",
-      "resolved":
-        "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
       "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+    },
+    "url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+        }
+      }
     },
     "util-deprecate": {
       "version": "1.0.2",
-      "resolved":
-        "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-      "integrity":
-        "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
+      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
     },
     "verror": {
       "version": "1.10.0",
@@ -3227,10 +3432,8 @@
     },
     "virtual-alexa": {
       "version": "0.6.9",
-      "resolved":
-        "https://registry.npmjs.org/virtual-alexa/-/virtual-alexa-0.6.9.tgz",
-      "integrity":
-        "sha512-f7vFVJ1fiJPh7GZGSpx2iQMqDvp/lWJ/44Mx/QXzSHWP4NtAR8NWF9k54BKlSUpbtyI5NbIMPk5TTyzUr2x55A==",
+      "resolved": "https://registry.npmjs.org/virtual-alexa/-/virtual-alexa-0.6.9.tgz",
+      "integrity": "sha512-f7vFVJ1fiJPh7GZGSpx2iQMqDvp/lWJ/44Mx/QXzSHWP4NtAR8NWF9k54BKlSUpbtyI5NbIMPk5TTyzUr2x55A==",
       "dev": true,
       "requires": {
         "aws-sdk": "^2.246.1",
@@ -3240,47 +3443,17 @@
         "virtual-core": "0.0.12"
       },
       "dependencies": {
-        "aws-sdk": {
-          "version": "2.262.1",
-          "resolved":
-            "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.262.1.tgz",
-          "integrity":
-            "sha512-SF7Zugvb5mQyvdBU80LIS+tIbBwl8G3HTcwgqA6d0p8qouC/mHpTprpLjhtmwJmFILWeBzjUt76fPw1XZXWtrw==",
-          "dev": true,
-          "requires": {
-            "buffer": "4.9.1",
-            "events": "1.1.1",
-            "ieee754": "1.1.8",
-            "jmespath": "0.15.0",
-            "querystring": "0.2.0",
-            "sax": "1.2.1",
-            "url": "0.10.3",
-            "uuid": "3.1.0",
-            "xml2js": "0.4.17"
-          },
-          "dependencies": {
-            "uuid": {
-              "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-              "integrity":
-                "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
-              "dev": true
-            }
-          }
-        },
         "lodash": {
           "version": "4.17.10",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-          "integrity":
-            "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
           "dev": true
         }
       }
     },
     "virtual-core": {
       "version": "0.0.12",
-      "resolved":
-        "https://registry.npmjs.org/virtual-core/-/virtual-core-0.0.12.tgz",
+      "resolved": "https://registry.npmjs.org/virtual-core/-/virtual-core-0.0.12.tgz",
       "integrity": "sha1-YxreHH8WiZK44jUyWB6QFn+qGdQ=",
       "dev": true,
       "requires": {
@@ -3290,8 +3463,7 @@
     },
     "webworker-threads": {
       "version": "0.7.13",
-      "resolved":
-        "https://registry.npmjs.org/webworker-threads/-/webworker-threads-0.7.13.tgz",
+      "resolved": "https://registry.npmjs.org/webworker-threads/-/webworker-threads-0.7.13.tgz",
       "integrity": "sha1-yEsYtrokElu503NC5E3rgVFi+4M=",
       "requires": {
         "bindings": "^1.2.1",
@@ -3301,29 +3473,26 @@
     "winston": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/winston/-/winston-3.0.0.tgz",
-      "integrity":
-        "sha512-7QyfOo1PM5zGL6qma6NIeQQMh71FBg/8fhkSAePqtf5YEi6t+UrPDcUuHhuuUasgso49ccvMEsmqr0GBG2qaMQ==",
+      "integrity": "sha512-7QyfOo1PM5zGL6qma6NIeQQMh71FBg/8fhkSAePqtf5YEi6t+UrPDcUuHhuuUasgso49ccvMEsmqr0GBG2qaMQ==",
       "requires": {
-        "async": "2.6.1",
-        "diagnostics": "1.1.0",
-        "is-stream": "1.1.0",
-        "logform": "1.9.1",
+        "async": "^2.6.0",
+        "diagnostics": "^1.0.1",
+        "is-stream": "^1.1.0",
+        "logform": "^1.9.0",
         "one-time": "0.0.4",
-        "readable-stream": "2.3.6",
-        "stack-trace": "0.0.10",
-        "triple-beam": "1.3.0",
-        "winston-transport": "4.2.0"
+        "readable-stream": "^2.3.6",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.2.0"
       }
     },
     "winston-transport": {
       "version": "4.2.0",
-      "resolved":
-        "https://registry.npmjs.org/winston-transport/-/winston-transport-4.2.0.tgz",
-      "integrity":
-        "sha512-0R1bvFqxSlK/ZKTH86nymOuKv/cT1PQBMuDdA7k7f0S9fM44dNH6bXnuxwXPrN8lefJgtZq08BKdyZ0DZIy/rg==",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.2.0.tgz",
+      "integrity": "sha512-0R1bvFqxSlK/ZKTH86nymOuKv/cT1PQBMuDdA7k7f0S9fM44dNH6bXnuxwXPrN8lefJgtZq08BKdyZ0DZIy/rg==",
       "requires": {
-        "readable-stream": "2.3.6",
-        "triple-beam": "1.3.0"
+        "readable-stream": "^2.3.6",
+        "triple-beam": "^1.2.0"
       }
     },
     "wordwrap": {
@@ -3335,6 +3504,23 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "xml2js": {
+      "version": "0.4.17",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
+      "integrity": "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg=",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "^4.1.0"
+      }
+    },
+    "xmlbuilder": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
+      "integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=",
+      "requires": {
+        "lodash": "^4.0.0"
+      }
     }
   }
 }

--- a/lambda/custom/package.json
+++ b/lambda/custom/package.json
@@ -4,17 +4,25 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "nyc --reporter=html --reporter=text mocha",
+    "travis": "nyc mocha && nyc report --reporter=text-lcov | coveralls"
   },
   "dependencies": {
     "alexa-sdk": "^1.0.25",
     "fuse": "^0.4.0",
-    "fuse.js": "^3.2.0",
+    "fuse.js": "^3.2.1",
     "natural": "0.5.1",
-    "request": "^2.83.0",
+    "request": "^2.87.0",
     "request-promise": "^4.2.2",
     "string-score": "^1.0.1"
   },
   "author": "Tamara Hills",
-  "license": "MPL-2.0"
+  "license": "MPL-2.0",
+  "devDependencies": {
+    "chai": "^4.1.2",
+    "coveralls": "^3.0.1",
+    "mocha": "^5.2.0",
+    "nyc": "^12.0.2",
+    "virtual-alexa": "^0.6.9"
+  }
 }

--- a/lambda/custom/package.json
+++ b/lambda/custom/package.json
@@ -21,9 +21,12 @@
   "author": "Tamara Hills",
   "license": "MPL-2.0",
   "devDependencies": {
+    "assertion-error": "^1.1.0",
+    "aws-sdk": "^2.266.1",
     "chai": "^4.1.2",
-    "coveralls": "^3.0.1",
+    "coveralls": "^3.0.2",
     "mocha": "^5.2.0",
+    "mocha-lcov-reporter": "^1.3.0",
     "nyc": "^12.0.2",
     "virtual-alexa": "^0.6.9"
   }

--- a/lambda/custom/state_handlers.js
+++ b/lambda/custom/state_handlers.js
@@ -68,6 +68,13 @@ var state_handlers = {
         console.log('PLAY_MODE:AMAZON.ResumeIntent');
         audio_controller.play.call(this);
       },
+      'AMAZON.RepeatIntent': function() {
+        console.log('START_MODE:AMAZON.RepeatIntent');
+        this.response
+          .speak(constants.strings.WELCOME_MSG)
+          .listen(constants.strings.WELCOME_REPROMPT);
+        this.emit(':responseReady');
+      },
       SessionEndedRequest: function() {
         console.log('START_MODE:AMAZON.SessionEndedRequest');
         // No session ended logic
@@ -408,7 +415,7 @@ function matchArticleToTitlesHelper(stateObj) {
 }
 
 async function searchAndPlayArticleHelper(stateObj) {
-  if (stateObj.event.session.new) {
+  if (stateObj.event.session.new || !stateObj.attributes['titles']) {
     const titles = await scout_agent.handleTitles(stateObj.event);
     stateObj.attributes['titles'] = titles;
   }
@@ -437,7 +444,7 @@ function getTitlesHelper(stateObj) {
       stateObj.emit(':responseReady');
     },
     error => {
-      stateObj.response.speak('Error Getting titles');
+      stateObj.response.speak(constants.strings.ERROR_GETTING_TITLES);
       stateObj.emit(':responseReady');
     }
   );

--- a/lambda/custom/test/tests.js
+++ b/lambda/custom/test/tests.js
@@ -12,26 +12,6 @@ alexa.context().setAccessToken('scoutskilltest@mailinator.com');
 
 const checkStreamingString = '.mp3';
 
-const util = require('util');
-const fs = require('fs');
-const log = fs.createWriteStream('./stdout.log');
-
-const DISABLE_STDOUT = true;
-// hide console.log outputs
-if (DISABLE_STDOUT) {
-  console.log = console.info = function(t) {
-    var out;
-    if (t && ~t.indexOf('%')) {
-      out = util.format.apply(util, arguments);
-      process.stdout.write(out + '\n');
-      return;
-    } else {
-      out = Array.prototype.join.call(arguments, ' ');
-    }
-    out && log.write(out + '\n');
-  };
-}
-
 describe('Unit Tests', function() {
   this.timeout(120 * 1000);
   it('Launch Prompt', async () => {

--- a/lambda/custom/test/tests.js
+++ b/lambda/custom/test/tests.js
@@ -3,7 +3,13 @@ AWS.config.update({ region: 'us-east-1' });
 const assert = require('chai').assert;
 const vax = require('virtual-alexa');
 const constants = require('../constants');
-// You need to setup the same ENV var as the Lambda function
+const logger = require('../logger');
+
+if (!process.env.SCOUT_ADDR || !process.env.JWOT_TOKEN) {
+  logger.error('No env vars found.');
+  throw new Error('No env vars found. Please add SCOUT_ADDR and JWOT_TOKEN.');
+}
+
 const alexa = vax.VirtualAlexa.Builder()
   .handler('index.handler') // Lambda function file and name
   .interactionModelFile('../../models/en-US.json')
@@ -12,7 +18,7 @@ alexa.context().setAccessToken('scoutskilltest@mailinator.com');
 
 const checkStreamingString = '.mp3';
 
-describe('Unit Tests', function() {
+describe('Integration Tests', function() {
   this.timeout(120 * 1000);
   it('Launch Prompt', async () => {
     let result = await alexa.launch();
@@ -102,11 +108,6 @@ describe('Unit Tests', function() {
     result = await alexa.utter('Pause');
     assert.isNotTrue(alexa.audioPlayer().isPlaying());
   });
-  /*it('Resume', async () => {
-    let result = await alexa.launch();
-    result = await alexa.utter('Resume');
-    assert.isTrue(alexa.audioPlayer().isPlaying());
-  });*/
   it('Cancel', async () => {
     let result = await alexa.launch();
     result = await alexa.utter('Cancel');
@@ -504,7 +505,6 @@ describe('Integration Tests', function() {
       assert.isTrue(alexa.audioPlayer().isPlaying());
 
       result = await alexa.utter('get titles');
-      //assert.isNotTrue(alexa.audioPlayer().isPlaying());
       assert.include(result.prompt(), constants.strings.TITLE_ANN);
 
       await alexa.audioPlayer().playbackFinished();
@@ -531,17 +531,8 @@ describe('Integration Tests', function() {
       assert.isTrue(alexa.audioPlayer().isPlaying());
 
       result = await alexa.utter('Play Donald Trump');
-      //assert.isNotTrue(alexa.audioPlayer().isPlaying());
       assert.include(result.prompt(), constants.strings.TITLE_CHOOSE_SUMM_FULL);
       result = await alexa.utter('full article');
-      /*assert.include(
-        result.response.directives[0].audioItem.stream.url,
-        checkStreamingString
-      );
-      assert.notEqual(
-        result.response.directives[0].audioItem.stream.url,
-        firstArticle
-      );*/
       assert.isTrue(alexa.audioPlayer().isPlaying());
 
       await alexa.audioPlayer().playbackFinished();

--- a/lambda/custom/test/tests.js
+++ b/lambda/custom/test/tests.js
@@ -1,0 +1,886 @@
+var AWS = require('aws-sdk');
+AWS.config.update({ region: 'us-east-1' });
+const assert = require('chai').assert;
+const vax = require('virtual-alexa');
+const constants = require('../constants');
+// You need to setup the same ENV var as the Lambda function
+const alexa = vax.VirtualAlexa.Builder()
+  .handler('index.handler') // Lambda function file and name
+  .interactionModelFile('../../models/en-US.json')
+  .create();
+alexa.context().setAccessToken('scoutskilltest@mailinator.com');
+
+const checkStreamingString = '.mp3';
+
+const util = require('util');
+const fs = require('fs');
+const log = fs.createWriteStream('./stdout.log');
+
+const DISABLE_STDOUT = true;
+// hide console.log outputs
+if (DISABLE_STDOUT) {
+  console.log = console.info = function(t) {
+    var out;
+    if (t && ~t.indexOf('%')) {
+      out = util.format.apply(util, arguments);
+      process.stdout.write(out + '\n');
+      return;
+    } else {
+      out = Array.prototype.join.call(arguments, ' ');
+    }
+    out && log.write(out + '\n');
+  };
+}
+
+describe('Unit Tests', function() {
+  this.timeout(120 * 1000);
+  it('Launch Prompt', async () => {
+    let result = await alexa.launch();
+    assert.include(result.prompt(), constants.strings.WELCOME_MSG);
+  });
+  it('Launch Reprompt', async () => {
+    let result = await alexa.launch();
+    assert.include(result.reprompt(), constants.strings.WELCOME_REPROMPT);
+  });
+  it('Get my titles', async () => {
+    let result = await alexa.launch();
+    result = await alexa.utter('Get my titles');
+    assert.include(result.prompt(), constants.strings.TITLE_ANN);
+    assert.include(result.prompt(), constants.strings.TITLE_CHOICE_EXPLAIN);
+    assert.include(
+      result.reprompt(),
+      constants.strings.TITLE_CHOICE_EXPLAIN_REPROMPT
+    );
+  });
+  it('Get titles', async () => {
+    let result = await alexa.launch();
+    result = await alexa.utter('Get Titles');
+    assert.include(result.prompt(), constants.strings.TITLE_ANN);
+    assert.include(result.prompt(), constants.strings.TITLE_CHOICE_EXPLAIN);
+    assert.include(
+      result.reprompt(),
+      constants.strings.TITLE_CHOICE_EXPLAIN_REPROMPT
+    );
+  });
+  it('Titles', async () => {
+    let result = await alexa.launch();
+    result = await alexa.utter('Titles');
+    assert.include(result.prompt(), constants.strings.TITLE_ANN);
+    assert.include(result.prompt(), constants.strings.TITLE_CHOICE_EXPLAIN);
+    assert.include(
+      result.reprompt(),
+      constants.strings.TITLE_CHOICE_EXPLAIN_REPROMPT
+    );
+  });
+  it('Play the article about Firefox', async () => {
+    let result = await alexa.launch();
+    result = await alexa.utter('Play the Article about Firefox');
+    assert.include(result.prompt(), constants.strings.TITLE_CHOOSE_SUMM_FULL);
+    assert.include(result.reprompt(), constants.strings.TITLE_CHOICE_REPROMPT);
+  });
+  it('Play Firefox', async () => {
+    let result = await alexa.launch();
+    result = await alexa.utter('Play Firefox');
+    assert.include(result.prompt(), constants.strings.TITLE_CHOOSE_SUMM_FULL);
+    assert.include(result.reprompt(), constants.strings.TITLE_CHOICE_REPROMPT);
+  });
+  it('Play (Match fail)', async () => {
+    let result = await alexa.launch();
+    result = await alexa.utter('Play something');
+    assert.include(result.prompt(), constants.strings.TITLE_SEARCH_MATCH_FAIL);
+    assert.include(
+      result.reprompt(),
+      constants.strings.TITLE_SEARCH_MATCH_FAIL
+    );
+  });
+  it('Play the article (Match fail)', async () => {
+    let result = await alexa.launch();
+    result = await alexa.utter('Play the article');
+    assert.include(result.prompt(), constants.strings.TITLE_SEARCH_MATCH_FAIL);
+    assert.include(
+      result.reprompt(),
+      constants.strings.TITLE_SEARCH_MATCH_FAIL
+    );
+  });
+  it('Help prompt', async () => {
+    let result = await alexa.launch();
+    result = await alexa.utter('Help');
+    assert.include(result.prompt(), constants.strings.START_HELP);
+  });
+  it('Help reprompt', async () => {
+    let result = await alexa.launch();
+    result = await alexa.utter('Help');
+    assert.include(result.reprompt(), constants.strings.START_HELP);
+  });
+  it('Stop', async () => {
+    let result = await alexa.launch();
+    result = await alexa.utter('Stop');
+    assert.include(result.prompt(), constants.strings.ALEXA_STOP_RESP);
+  });
+  it('Pause', async () => {
+    let result = await alexa.launch();
+    result = await alexa.utter('Pause');
+    assert.isNotTrue(alexa.audioPlayer().isPlaying());
+  });
+  /*it('Resume', async () => {
+    let result = await alexa.launch();
+    result = await alexa.utter('Resume');
+    assert.isTrue(alexa.audioPlayer().isPlaying());
+  });*/
+  it('Cancel', async () => {
+    let result = await alexa.launch();
+    result = await alexa.utter('Cancel');
+    assert.include(result.prompt(), constants.strings.ALEXA_STOP_RESP);
+  });
+  it('Repeat', async () => {
+    let result = await alexa.launch();
+    result = await alexa.utter('Repeat');
+    assert.include(result.prompt(), constants.strings.WELCOME_MSG);
+    assert.include(result.reprompt(), constants.strings.WELCOME_REPROMPT);
+  });
+  it('EndSession', async () => {
+    let result = await alexa.launch();
+    result = await alexa.endSession();
+  });
+  it('Unhandled', async () => {
+    let result = await alexa.launch();
+    result = await alexa.intend('AMAZON.FallbackIntent');
+    assert.include(result.prompt(), constants.strings.ERROR_UNHANDLED_STATE);
+    assert.include(result.reprompt(), constants.strings.ERROR_UNHANDLED_STATE);
+  });
+  it('ScoutMyPocket', async () => {
+    let result = await alexa.launch();
+    result = await alexa.utter('pocket');
+    assert.isTrue(alexa.audioPlayer().isPlaying());
+
+    result = await alexa.utter('stop');
+    assert.isNotTrue(alexa.audioPlayer().isPlaying());
+  });
+});
+
+describe('Integration Tests', function() {
+  this.timeout(120 * 1000);
+
+  afterEach(async function() {
+    result = await alexa.utter('stop');
+    assert.isNotTrue(alexa.audioPlayer().isPlaying());
+  });
+
+  describe('Happy Dialog Paths', function() {
+    it('Full Article - Test 1', async () => {
+      let result = await alexa.launch();
+      assert.include(result.prompt(), constants.strings.WELCOME_MSG);
+      assert.include(result.reprompt(), constants.strings.WELCOME_REPROMPT);
+
+      result = await alexa.utter('get my titles');
+      assert.include(result.prompt(), constants.strings.TITLE_ANN);
+
+      result = await alexa.utter('Play the Article about Firefox');
+      assert.include(result.prompt(), constants.strings.TITLE_CHOOSE_SUMM_FULL);
+
+      result = await alexa.utter('full article');
+      assert.include(
+        result.response.directives[0].audioItem.stream.url,
+        checkStreamingString
+      );
+      assert.isTrue(alexa.audioPlayer().isPlaying());
+
+      result = await alexa.utter('stop');
+      assert.isNotTrue(alexa.audioPlayer().isPlaying());
+    });
+
+    it('Full Article - Test 2', async () => {
+      let result = await alexa.launch();
+      assert.include(result.prompt(), constants.strings.WELCOME_MSG);
+      assert.include(result.reprompt(), constants.strings.WELCOME_REPROMPT);
+
+      result = await alexa.utter('Titles');
+      assert.include(result.prompt(), constants.strings.TITLE_ANN);
+
+      result = await alexa.utter('Play Blockchain');
+      assert.include(result.prompt(), constants.strings.TITLE_CHOOSE_SUMM_FULL);
+
+      result = await alexa.utter('entire story');
+      assert.include(
+        result.response.directives[0].audioItem.stream.url,
+        checkStreamingString
+      );
+      assert.isTrue(alexa.audioPlayer().isPlaying());
+
+      result = await alexa.utter('stop');
+      assert.isNotTrue(alexa.audioPlayer().isPlaying());
+    });
+
+    it('Full Article - Test 3', async () => {
+      let result = await alexa.launch();
+      assert.include(result.prompt(), constants.strings.WELCOME_MSG);
+      assert.include(result.reprompt(), constants.strings.WELCOME_REPROMPT);
+
+      result = await alexa.utter('Titles');
+      assert.include(result.prompt(), constants.strings.TITLE_ANN);
+
+      result = await alexa.utter('Play the Amazon TV article');
+      assert.include(result.prompt(), constants.strings.TITLE_CHOOSE_SUMM_FULL);
+
+      result = await alexa.utter('full story');
+      assert.include(
+        result.response.directives[0].audioItem.stream.url,
+        checkStreamingString
+      );
+      assert.isTrue(alexa.audioPlayer().isPlaying());
+
+      result = await alexa.utter('stop');
+      assert.isNotTrue(alexa.audioPlayer().isPlaying());
+    });
+
+    it('Summary - Test 1', async () => {
+      let result = await alexa.launch();
+      assert.include(result.prompt(), constants.strings.WELCOME_MSG);
+      assert.include(result.reprompt(), constants.strings.WELCOME_REPROMPT);
+
+      result = await alexa.utter('get my titles');
+      assert.include(result.prompt(), constants.strings.TITLE_ANN);
+
+      result = await alexa.utter('Play the Article about Firefox');
+      assert.include(result.prompt(), constants.strings.TITLE_CHOOSE_SUMM_FULL);
+
+      result = await alexa.utter('summary');
+      assert.include(
+        result.response.directives[0].audioItem.stream.url,
+        checkStreamingString
+      );
+      assert.isTrue(alexa.audioPlayer().isPlaying());
+
+      result = await alexa.utter('stop');
+      assert.isNotTrue(alexa.audioPlayer().isPlaying());
+    });
+
+    it('Summary - Test 2', async () => {
+      let result = await alexa.launch();
+      assert.include(result.prompt(), constants.strings.WELCOME_MSG);
+      assert.include(result.reprompt(), constants.strings.WELCOME_REPROMPT);
+
+      result = await alexa.utter('Titles');
+      assert.include(result.prompt(), constants.strings.TITLE_ANN);
+
+      result = await alexa.utter('Play Boring Company');
+      assert.include(result.prompt(), constants.strings.TITLE_CHOOSE_SUMM_FULL);
+
+      result = await alexa.utter('skim');
+      assert.include(
+        result.response.directives[0].audioItem.stream.url,
+        checkStreamingString
+      );
+      assert.isTrue(alexa.audioPlayer().isPlaying());
+
+      result = await alexa.utter('stop');
+      assert.isNotTrue(alexa.audioPlayer().isPlaying());
+    });
+
+    it('Summary - Test 3', async () => {
+      let result = await alexa.launch();
+      assert.include(result.prompt(), constants.strings.WELCOME_MSG);
+      assert.include(result.reprompt(), constants.strings.WELCOME_REPROMPT);
+
+      result = await alexa.utter('Titles');
+      assert.include(result.prompt(), constants.strings.TITLE_ANN);
+
+      result = await alexa.utter('Play Donald Trump');
+      assert.include(result.prompt(), constants.strings.TITLE_CHOOSE_SUMM_FULL);
+
+      result = await alexa.utter('get me a summary');
+      assert.include(
+        result.response.directives[0].audioItem.stream.url,
+        checkStreamingString
+      );
+      assert.isTrue(alexa.audioPlayer().isPlaying());
+
+      result = await alexa.utter('stop');
+      assert.isNotTrue(alexa.audioPlayer().isPlaying());
+    });
+
+    it('Full Article - Pause/Resume', async () => {
+      let result = await alexa.launch();
+      assert.include(result.prompt(), constants.strings.WELCOME_MSG);
+      assert.include(result.reprompt(), constants.strings.WELCOME_REPROMPT);
+
+      result = await alexa.utter('get titles');
+      assert.include(result.prompt(), constants.strings.TITLE_ANN);
+
+      result = await alexa.utter('Play Donald Trump');
+      assert.include(result.prompt(), constants.strings.TITLE_CHOOSE_SUMM_FULL);
+
+      result = await alexa.utter('full article');
+      assert.include(
+        result.response.directives[0].audioItem.stream.url,
+        checkStreamingString
+      );
+      assert.isTrue(alexa.audioPlayer().isPlaying());
+
+      result = await alexa.utter('pause');
+      assert.isNotTrue(alexa.audioPlayer().isPlaying());
+
+      result = await alexa.utter('resume');
+      assert.isTrue(alexa.audioPlayer().isPlaying());
+
+      result = await alexa.utter('stop');
+      assert.isNotTrue(alexa.audioPlayer().isPlaying());
+    });
+
+    it('Full Article - Stop/Resume', async () => {
+      let result = await alexa.launch();
+      assert.include(result.prompt(), constants.strings.WELCOME_MSG);
+      assert.include(result.reprompt(), constants.strings.WELCOME_REPROMPT);
+
+      result = await alexa.utter('get titles');
+      assert.include(result.prompt(), constants.strings.TITLE_ANN);
+
+      result = await alexa.utter('Play Firefox');
+      assert.include(result.prompt(), constants.strings.TITLE_CHOOSE_SUMM_FULL);
+
+      result = await alexa.utter('full article');
+      assert.include(
+        result.response.directives[0].audioItem.stream.url,
+        checkStreamingString
+      );
+      assert.isTrue(alexa.audioPlayer().isPlaying());
+
+      result = await alexa.utter('stop');
+      assert.isNotTrue(alexa.audioPlayer().isPlaying());
+
+      result = await alexa.utter('resume');
+      assert.isTrue(alexa.audioPlayer().isPlaying());
+
+      result = await alexa.utter('stop');
+      assert.isNotTrue(alexa.audioPlayer().isPlaying());
+    });
+
+    it('Summary - Pause/Resume', async () => {
+      let result = await alexa.launch();
+      assert.include(result.prompt(), constants.strings.WELCOME_MSG);
+      assert.include(result.reprompt(), constants.strings.WELCOME_REPROMPT);
+
+      result = await alexa.utter('get titles');
+      assert.include(result.prompt(), constants.strings.TITLE_ANN);
+
+      result = await alexa.utter('Play Donald Trump');
+      assert.include(result.prompt(), constants.strings.TITLE_CHOOSE_SUMM_FULL);
+
+      result = await alexa.utter('summary');
+      assert.include(
+        result.response.directives[0].audioItem.stream.url,
+        checkStreamingString
+      );
+      assert.isTrue(alexa.audioPlayer().isPlaying());
+
+      result = await alexa.utter('pause');
+      assert.isNotTrue(alexa.audioPlayer().isPlaying());
+
+      result = await alexa.utter('resume');
+      assert.isTrue(alexa.audioPlayer().isPlaying());
+
+      result = await alexa.utter('stop');
+      assert.isNotTrue(alexa.audioPlayer().isPlaying());
+    });
+
+    it('Summary - Stop/Resume', async () => {
+      let result = await alexa.launch();
+      assert.include(result.prompt(), constants.strings.WELCOME_MSG);
+      assert.include(result.reprompt(), constants.strings.WELCOME_REPROMPT);
+
+      result = await alexa.utter('get titles');
+      assert.include(result.prompt(), constants.strings.TITLE_ANN);
+
+      result = await alexa.utter('Play Firefox');
+      assert.include(result.prompt(), constants.strings.TITLE_CHOOSE_SUMM_FULL);
+
+      result = await alexa.utter('summary');
+      assert.include(
+        result.response.directives[0].audioItem.stream.url,
+        checkStreamingString
+      );
+      assert.isTrue(alexa.audioPlayer().isPlaying());
+
+      result = await alexa.utter('pause');
+      assert.isNotTrue(alexa.audioPlayer().isPlaying());
+
+      result = await alexa.utter('resume');
+      assert.isTrue(alexa.audioPlayer().isPlaying());
+
+      result = await alexa.utter('stop');
+      assert.isNotTrue(alexa.audioPlayer().isPlaying());
+    });
+  });
+  describe('Other Paths', function() {
+    it('Get Titles - Repeat', async () => {
+      let result = await alexa.launch();
+      assert.include(result.prompt(), constants.strings.WELCOME_MSG);
+      assert.include(result.reprompt(), constants.strings.WELCOME_REPROMPT);
+
+      result = await alexa.utter('get titles');
+      assert.include(result.prompt(), constants.strings.TITLE_ANN);
+
+      result = await alexa.utter('repeat');
+      assert.include(result.prompt(), constants.strings.TITLES_REPEAT);
+      assert.include(result.prompt(), constants.strings.TITLE_CHOICE_EXPLAIN);
+    });
+
+    it('Get Titles - Next', async () => {
+      let result = await alexa.launch();
+      assert.include(result.prompt(), constants.strings.WELCOME_MSG);
+      assert.include(result.reprompt(), constants.strings.WELCOME_REPROMPT);
+
+      result = await alexa.utter('get titles');
+      assert.include(result.prompt(), constants.strings.TITLE_ANN);
+
+      result = await alexa.utter('next');
+      assert.include(result.prompt(), constants.strings.TITLE_PREFIX);
+      assert.include(result.prompt(), constants.strings.TITLE_CHOICE_EXPLAIN);
+      assert.include(
+        result.reprompt(),
+        constants.strings.TITLE_CHOICE_EXPLAIN_REPROMPT
+      );
+    });
+
+    it('Get Titles - Next - Repeat', async () => {
+      let result = await alexa.launch();
+      assert.include(result.prompt(), constants.strings.WELCOME_MSG);
+      assert.include(result.reprompt(), constants.strings.WELCOME_REPROMPT);
+
+      result = await alexa.utter('get titles');
+      assert.include(result.prompt(), constants.strings.TITLE_ANN);
+
+      result = await alexa.utter('next');
+      assert.include(result.prompt(), constants.strings.TITLE_PREFIX);
+      assert.include(result.prompt(), constants.strings.TITLE_CHOICE_EXPLAIN);
+      assert.include(
+        result.reprompt(),
+        constants.strings.TITLE_CHOICE_EXPLAIN_REPROMPT
+      );
+
+      result = await alexa.utter('repeat');
+      assert.include(result.prompt(), constants.strings.TITLES_REPEAT);
+      assert.include(result.prompt(), constants.strings.TITLE_CHOICE_EXPLAIN);
+    });
+
+    it('Get Titles - Get Titles', async () => {
+      let result = await alexa.launch();
+
+      result = await alexa.utter('get titles');
+      assert.include(result.prompt(), constants.strings.TITLE_ANN);
+
+      result = await alexa.utter('get titles');
+      assert.include(result.prompt(), constants.strings.TITLE_ANN);
+    });
+
+    it('Get Titles - Relaunch', async () => {
+      let result = await alexa.launch();
+
+      result = await alexa.utter('get titles');
+      assert.include(result.prompt(), constants.strings.TITLE_ANN);
+
+      result = await alexa.launch();
+      assert.include(result.prompt(), constants.strings.WELCOME_MSG);
+
+      result = await alexa.utter('get titles');
+      assert.include(result.prompt(), constants.strings.TITLE_ANN);
+    });
+
+    it('PlaybackFinished', async () => {
+      let result = await alexa.launch();
+
+      result = await alexa.utter('get titles');
+      assert.include(result.prompt(), constants.strings.TITLE_ANN);
+
+      result = await alexa.utter('Play Firefox');
+      assert.include(result.prompt(), constants.strings.TITLE_CHOOSE_SUMM_FULL);
+
+      result = await alexa.utter('full article');
+      assert.include(
+        result.response.directives[0].audioItem.stream.url,
+        checkStreamingString
+      );
+      assert.isTrue(alexa.audioPlayer().isPlaying());
+
+      await alexa.audioPlayer().playbackNearlyFinished();
+      await alexa.audioPlayer().playbackFinished();
+      assert.isNotTrue(alexa.audioPlayer().isPlaying());
+    });
+
+    it('PlayMode - Get Titles', async () => {
+      let result = await alexa.launch();
+
+      result = await alexa.utter('get titles');
+      assert.include(result.prompt(), constants.strings.TITLE_ANN);
+
+      result = await alexa.utter('Play Firefox');
+      assert.include(result.prompt(), constants.strings.TITLE_CHOOSE_SUMM_FULL);
+
+      result = await alexa.utter('full article');
+      assert.include(
+        result.response.directives[0].audioItem.stream.url,
+        checkStreamingString
+      );
+      assert.isTrue(alexa.audioPlayer().isPlaying());
+
+      result = await alexa.utter('get titles');
+      //assert.isNotTrue(alexa.audioPlayer().isPlaying());
+      assert.include(result.prompt(), constants.strings.TITLE_ANN);
+
+      await alexa.audioPlayer().playbackFinished();
+      assert.isNotTrue(alexa.audioPlayer().isPlaying());
+    });
+
+    it('PlayMode - Play different article', async () => {
+      let result = await alexa.launch();
+      assert.include(result.prompt(), constants.strings.WELCOME_MSG);
+      assert.include(result.reprompt(), constants.strings.WELCOME_REPROMPT);
+
+      result = await alexa.utter('get titles');
+      assert.include(result.prompt(), constants.strings.TITLE_ANN);
+
+      result = await alexa.utter('Play Firefox');
+      assert.include(result.prompt(), constants.strings.TITLE_CHOOSE_SUMM_FULL);
+
+      result = await alexa.utter('full article');
+      assert.include(
+        result.response.directives[0].audioItem.stream.url,
+        checkStreamingString
+      );
+      let firstArticle = result.response.directives[0].audioItem.stream.url;
+      assert.isTrue(alexa.audioPlayer().isPlaying());
+
+      result = await alexa.utter('Play Donald Trump');
+      //assert.isNotTrue(alexa.audioPlayer().isPlaying());
+      assert.include(result.prompt(), constants.strings.TITLE_CHOOSE_SUMM_FULL);
+      result = await alexa.utter('full article');
+      /*assert.include(
+        result.response.directives[0].audioItem.stream.url,
+        checkStreamingString
+      );
+      assert.notEqual(
+        result.response.directives[0].audioItem.stream.url,
+        firstArticle
+      );*/
+      assert.isTrue(alexa.audioPlayer().isPlaying());
+
+      await alexa.audioPlayer().playbackFinished();
+      assert.isNotTrue(alexa.audioPlayer().isPlaying());
+    });
+
+    it('PlayMode - ScoutMyPocket', async () => {
+      let result = await alexa.launch();
+
+      result = await alexa.utter('get titles');
+      assert.include(result.prompt(), constants.strings.TITLE_ANN);
+
+      result = await alexa.utter('Play Firefox');
+      assert.include(result.prompt(), constants.strings.TITLE_CHOOSE_SUMM_FULL);
+
+      result = await alexa.utter('full article');
+      assert.include(
+        result.response.directives[0].audioItem.stream.url,
+        checkStreamingString
+      );
+      let firstArticle = result.response.directives[0].audioItem.stream.url;
+      assert.isTrue(alexa.audioPlayer().isPlaying());
+
+      result = await alexa.utter('pocket');
+      assert.include(
+        result.response.directives[0].audioItem.stream.url,
+        checkStreamingString
+      );
+      assert.notEqual(
+        result.response.directives[0].audioItem.stream.url,
+        firstArticle
+      );
+      assert.isTrue(alexa.audioPlayer().isPlaying());
+
+      await alexa.audioPlayer().playbackFinished();
+      assert.isNotTrue(alexa.audioPlayer().isPlaying());
+    });
+
+    it('PlayMode - Cancel', async () => {
+      let result = await alexa.launch();
+
+      result = await alexa.utter('get titles');
+      assert.include(result.prompt(), constants.strings.TITLE_ANN);
+
+      result = await alexa.utter('Play Firefox');
+      assert.include(result.prompt(), constants.strings.TITLE_CHOOSE_SUMM_FULL);
+
+      result = await alexa.utter('full article');
+      assert.include(
+        result.response.directives[0].audioItem.stream.url,
+        checkStreamingString
+      );
+      let firstArticle = result.response.directives[0].audioItem.stream.url;
+      assert.isTrue(alexa.audioPlayer().isPlaying());
+
+      result = await alexa.utter('cancel');
+      assert.isNotTrue(alexa.audioPlayer().isPlaying());
+    });
+  });
+
+  describe('Help Paths', function() {
+    it('Get Titles - Help', async () => {
+      let result = await alexa.launch();
+
+      result = await alexa.utter('get titles');
+      assert.include(result.prompt(), constants.strings.TITLE_ANN);
+      assert.include(result.prompt(), constants.strings.TITLE_CHOICE_EXPLAIN);
+      assert.include(
+        result.reprompt(),
+        constants.strings.TITLE_CHOICE_EXPLAIN_REPROMPT
+      );
+
+      result = await alexa.utter('help');
+      assert.include(result.prompt(), constants.strings.TITLE_HELP);
+      assert.include(result.reprompt(), constants.strings.TITLE_HELP);
+    });
+
+    it('Get Titles - Next - Help', async () => {
+      let result = await alexa.launch();
+
+      result = await alexa.utter('get titles');
+      assert.include(result.prompt(), constants.strings.TITLE_ANN);
+
+      result = await alexa.utter('next');
+      assert.include(result.prompt(), constants.strings.TITLE_PREFIX);
+      assert.include(result.prompt(), constants.strings.TITLE_CHOICE_EXPLAIN);
+      assert.include(
+        result.reprompt(),
+        constants.strings.TITLE_CHOICE_EXPLAIN_REPROMPT
+      );
+
+      result = await alexa.utter('help');
+      assert.include(result.prompt(), constants.strings.TITLE_HELP);
+      assert.include(result.reprompt(), constants.strings.TITLE_HELP);
+    });
+
+    it('Summary or Full Article - Help', async () => {
+      let result = await alexa.launch();
+
+      result = await alexa.utter('get titles');
+      assert.include(result.prompt(), constants.strings.TITLE_ANN);
+
+      result = await alexa.utter('Play Firefox');
+      assert.include(result.prompt(), constants.strings.TITLE_CHOOSE_SUMM_FULL);
+
+      result = await alexa.utter('help');
+      assert.include(result.prompt(), constants.strings.TITLE_HELP);
+      assert.include(result.reprompt(), constants.strings.TITLE_HELP);
+    });
+
+    it('Playing - Help', async () => {
+      let result = await alexa.launch();
+
+      result = await alexa.utter('get titles');
+      assert.include(result.prompt(), constants.strings.TITLE_ANN);
+
+      result = await alexa.utter('Play Firefox');
+      assert.include(result.prompt(), constants.strings.TITLE_CHOOSE_SUMM_FULL);
+
+      result = await alexa.utter('full article');
+      assert.isTrue(alexa.audioPlayer().isPlaying());
+
+      result = await alexa.utter('help');
+      assert.include(result.prompt(), constants.strings.START_HELP);
+      assert.include(result.reprompt(), constants.strings.START_HELP);
+
+      result = await alexa.utter('stop');
+      assert.isNotTrue(alexa.audioPlayer().isPlaying());
+    });
+  });
+
+  describe('Error Paths', function() {
+    it('Get Titles - Next - Next: No more titles', async () => {
+      let result = await alexa.launch();
+
+      result = await alexa.utter('get titles');
+      assert.include(result.prompt(), constants.strings.TITLE_ANN);
+
+      result = await alexa.utter('next');
+      assert.include(result.prompt(), constants.strings.TITLE_PREFIX);
+      assert.include(result.prompt(), constants.strings.TITLE_CHOICE_EXPLAIN);
+      assert.include(
+        result.reprompt(),
+        constants.strings.TITLE_CHOICE_EXPLAIN_REPROMPT
+      );
+
+      result = await alexa.utter('next');
+      assert.include(result.prompt(), constants.strings.END_OF_TITLES);
+      assert.include(result.prompt(), constants.strings.TITLE_CHOICE_EXPLAIN);
+      assert.include(result.reprompt(), constants.strings.TITLE_CHOICE_EXPLAIN);
+    });
+
+    it('Get Titles - EndSession', async () => {
+      let result = await alexa.launch();
+
+      result = await alexa.utter('get titles');
+      assert.include(result.prompt(), constants.strings.TITLE_ANN);
+
+      result = await alexa.endSession();
+    });
+
+    it('Get Titles - Play undefined: No match', async () => {
+      let result = await alexa.launch();
+
+      result = await alexa.utter('get titles');
+      assert.include(result.prompt(), constants.strings.TITLE_ANN);
+
+      result = await alexa.utter('Play undefined');
+      assert.include(
+        result.prompt(),
+        constants.strings.TITLE_SEARCH_MATCH_FAIL
+      );
+      assert.include(
+        result.reprompt(),
+        constants.strings.TITLE_SEARCH_MATCH_FAIL
+      );
+    });
+
+    it('Get Titles - Unhandled', async () => {
+      let result = await alexa.launch();
+
+      result = await alexa.utter('get titles');
+      assert.include(result.prompt(), constants.strings.TITLE_ANN);
+
+      result = await alexa.intend('AMAZON.FallbackIntent');
+      assert.include(result.prompt(), constants.strings.ERROR_UNEXPECTED_STATE);
+      assert.include(
+        result.reprompt(),
+        constants.strings.ERROR_UNEXPECTED_STATE
+      );
+    });
+
+    it('Playing - EndSession', async () => {
+      let result = await alexa.launch();
+
+      result = await alexa.utter('get titles');
+      assert.include(result.prompt(), constants.strings.TITLE_ANN);
+
+      result = await alexa.utter('Play Firefox');
+      assert.include(result.prompt(), constants.strings.TITLE_CHOOSE_SUMM_FULL);
+
+      result = await alexa.utter('full article');
+      assert.isTrue(alexa.audioPlayer().isPlaying());
+
+      result = await alexa.endSession();
+    });
+
+    it('Playing - Unhandled', async () => {
+      let result = await alexa.launch();
+
+      result = await alexa.utter('get titles');
+      assert.include(result.prompt(), constants.strings.TITLE_ANN);
+
+      result = await alexa.utter('Play Firefox');
+      assert.include(result.prompt(), constants.strings.TITLE_CHOOSE_SUMM_FULL);
+
+      result = await alexa.utter('full article');
+      assert.isTrue(alexa.audioPlayer().isPlaying());
+
+      result = await alexa.intend('AMAZON.FallbackIntent');
+      assert.include(result.prompt(), constants.strings.PLAY_MODE_UNHANDLED);
+      assert.include(result.reprompt(), constants.strings.PLAY_MODE_UNHANDLED);
+    });
+  });
+});
+
+describe('Integration Tests - Account 2', function() {
+  this.timeout(120 * 1000);
+  before(function() {
+    alexa.context().setAccessToken('scoutskilltest2@mailinator.com');
+  });
+  afterEach(async function() {
+    result = await alexa.utter('stop');
+    assert.isNotTrue(alexa.audioPlayer().isPlaying());
+  });
+
+  it('Get Titles - Next - Next: No more titles', async () => {
+    let result = await alexa.launch();
+
+    result = await alexa.utter('get titles');
+    assert.include(result.prompt(), constants.strings.TITLE_ANN);
+
+    result = await alexa.utter('next');
+    assert.include(result.prompt(), constants.strings.TITLE_PREFIX);
+    assert.include(result.prompt(), constants.strings.TITLE_CHOICE_EXPLAIN);
+    assert.include(
+      result.reprompt(),
+      constants.strings.TITLE_CHOICE_EXPLAIN_REPROMPT
+    );
+
+    result = await alexa.utter('next');
+    assert.include(result.prompt(), constants.strings.END_OF_TITLES);
+    assert.include(result.prompt(), constants.strings.TITLE_CHOICE_EXPLAIN);
+    assert.include(result.reprompt(), constants.strings.TITLE_CHOICE_EXPLAIN);
+  });
+
+  it('Get Titles - Repeat', async () => {
+    let result = await alexa.launch();
+    assert.include(result.prompt(), constants.strings.WELCOME_MSG);
+    assert.include(result.reprompt(), constants.strings.WELCOME_REPROMPT);
+
+    result = await alexa.utter('get titles');
+    assert.include(result.prompt(), constants.strings.TITLE_ANN);
+
+    result = await alexa.utter('repeat');
+    assert.include(result.prompt(), constants.strings.TITLES_REPEAT);
+    assert.include(result.prompt(), constants.strings.TITLE_CHOICE_EXPLAIN);
+  });
+
+  it('Get Titles - Next', async () => {
+    let result = await alexa.launch();
+    assert.include(result.prompt(), constants.strings.WELCOME_MSG);
+    assert.include(result.reprompt(), constants.strings.WELCOME_REPROMPT);
+
+    result = await alexa.utter('get titles');
+    assert.include(result.prompt(), constants.strings.TITLE_ANN);
+
+    result = await alexa.utter('next');
+    assert.include(result.prompt(), constants.strings.TITLE_PREFIX);
+    assert.include(result.prompt(), constants.strings.TITLE_CHOICE_EXPLAIN);
+    assert.include(
+      result.reprompt(),
+      constants.strings.TITLE_CHOICE_EXPLAIN_REPROMPT
+    );
+  });
+
+  it('Get Titles - Next - Repeat', async () => {
+    let result = await alexa.launch();
+    assert.include(result.prompt(), constants.strings.WELCOME_MSG);
+    assert.include(result.reprompt(), constants.strings.WELCOME_REPROMPT);
+
+    result = await alexa.utter('get titles');
+    assert.include(result.prompt(), constants.strings.TITLE_ANN);
+
+    result = await alexa.utter('next');
+    assert.include(result.prompt(), constants.strings.TITLE_PREFIX);
+    assert.include(result.prompt(), constants.strings.TITLE_CHOICE_EXPLAIN);
+    assert.include(
+      result.reprompt(),
+      constants.strings.TITLE_CHOICE_EXPLAIN_REPROMPT
+    );
+
+    result = await alexa.utter('repeat');
+    assert.include(result.prompt(), constants.strings.TITLES_REPEAT);
+    assert.include(result.prompt(), constants.strings.TITLE_CHOICE_EXPLAIN);
+  });
+});
+
+describe('Integration Tests - Unregistered account / API down', function() {
+  this.timeout(120 * 1000);
+  before(function() {
+    alexa.context().setAccessToken('unregistered-user@mailinator.com');
+  });
+  it('Get Titles - Next', async () => {
+    let result = await alexa.launch();
+    assert.include(result.prompt(), constants.strings.WELCOME_MSG);
+    assert.include(result.reprompt(), constants.strings.WELCOME_REPROMPT);
+
+    result = await alexa.utter('get titles');
+    assert.include(result.prompt(), constants.strings.ERROR_GETTING_TITLES);
+  });
+});

--- a/models/en-US.json
+++ b/models/en-US.json
@@ -31,7 +31,7 @@
         {
           "name": "ScoutTitles",
           "slots": [],
-          "samples": ["get my titles", "titles"]
+          "samples": ["get my titles", "get titles", "titles"]
         },
         {
           "name": "SearchAndPlayArticle",


### PR DESCRIPTION
Fixes #57 
Fixes #79 

Adding tests to Alexa Skill using Bespoken virtual-alexa.
Use of two different accounts for testing: scoutskilltest@mailinator.com and scoutskilltest2@mailinator.com. At the moment the second one is only useful to have coverage over the case where the number of articles is a multiple of TITLE_CHUNK_LEN.

Current coverage is **88%.**

Before merging:

- Register both tests users in scout-stage.

Notes:

- When testing if the skill is playing a file, we just test that the Alexa is playing something (not especially the right file). That can be quite hard to implement since the file names are dynamic.

- We have a portion of code in audio_controller.js that might never execute. We have to investigate that. A branch of state_handlers.js also seem to never execute.

- We currently don't catch the Scout Unavailable rejection.

- SearchAndSummarizeArticle Intent is implemented in state_handlers.js but not declared in the model. So we are currently never executing this code.

- Yes and No intents don't make sense in our current implementation. They are not tested.

- Pause and Resume intents are implemented in every state. But they should only be used in the Play Mode state.

- We also lack in test coverage because cases when the API (scout-ua) is down are not currently tested.

- It seems like some test cases are not reproducible in real (like PlayMode - Play different article).

- Strange behavior of virtual-alexa when doing actions while playing audio (such as asking to play a different file while playing).

- As we are doing a lot of calls to the Pocket API in a very short interval of time, we could be rate limited when running the tests twice in a row.






