### PR TITLE
Fix Warning Application ID not set

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Create an AWS Lambda Function on [AWS Lambda](https://console.aws.amazon.com/lam
 
 Add the following environment variables to your Lambda function:
 
+* `APP_ID`: Alexa Skill ID. You can find it in the [Alexa Skills Kit Console](https://developer.amazon.com/alexa/console/ask)
 * `JWOT_TOKEN`: JWOT token to access API (scout-ua). Generate using the api/auth/register endpoint from scout-ua (POST request with `name`, `email`, `password` fields).
 * `SCOUT_ADDR`: API hostname for scout-ua (`yourserver.com` for instance)
 * `LOG_LEVEL`: Optional. [Winston](https://github.com/winstonjs/winston) logging level.

--- a/lambda/custom/index.js
+++ b/lambda/custom/index.js
@@ -8,6 +8,7 @@ var audioEventHandlers = require('./audioEventHandlers');
 exports.handler = function(event, context, callback) {
   var alexa = Alexa.handler(event, context, callback);
   alexa.dynamoDBTableName = constants.dynamoDBTableName;
+  alexa.appId = process.env.APP_ID;
   // Each state handler is mapped to a specific state.
   alexa.registerHandlers(
     stateHandlers.startModeIntentHandlers,


### PR DESCRIPTION
Fixes #92 

Add an environment variable APP_ID on scout-alexa lambda function. Needs to be set to the Alexa Skill ID.