### PR TITLE
Remove skill strings from constants

### DIFF
--- a/lambda/custom/constants.js
+++ b/lambda/custom/constants.js
@@ -1,42 +1,31 @@
 'use strict';
-const stringResources = require(process.env.STRING_BRAND);
 
-let constants = {};
-constants.strings = stringResources.en.translation;
-
-Object.assign(constants, {
+module.exports = Object.freeze({
   // App-ID. TODO: set to your own Skill App ID from the developer portal.
   appId: '',
   dynamoDBTableName: 'ScoutDB',
-
+  TITLE_CHUNK_LEN: 5,
+  USER_AGENT: 'Alexa Skill',
+  // when true, the skill logs additional detail, including the full request received from Alexa
+  debug: true,
   /*
-      *  States:
-      *  START_MODE : Welcome state when the audio list has not begun.
-      *  PLAY_MODE :  When a playlist is being played. Does not imply only active play.
-      *               It remains in the state as long as the playlist is not finished.
-      *  RESUME_DECISION_MODE : When a user invokes the skill in PLAY_MODE with a LaunchRequest,
-      *                         the skill provides an option to resume from last position, or to start over the playlist.
-      */
+     *  States:
+     *  START_MODE : Welcome state when the audio list has not begun.
+     *  PLAY_MODE :  When a playlist is being played. Does not imply only active play.
+     *               It remains in the state as long as the playlist is not finished.
+     *  RESUME_DECISION_MODE : When a user invokes the skill in PLAY_MODE with a LaunchRequest,
+     *                         the skill provides an option to resume from last position, or to start over the playlist.
+     */
   states: {
     START_MODE: '',
     PLAY_MODE: '_PLAY_MODE',
     RESUME_DECISION_MODE: '_RESUME_DECISION_MODE',
     TITLES_DECISION_MODE: '_TITLES_DECISION_MODE'
   },
-
   metrics: {
     GET_TITLES: 'listen_command',
     START_LISTEN: 'start_listen',
     REACH_END_LISTEN: 'reach_end_listen',
     CTX_CMD_GET_TITLES: 'get_titles'
-  },
-  TITLE_CHUNK_LEN: 5,
-  USER_AGENT: 'Alexa Skill',
-
-  // when true, the skill logs additional detail, including the full request received from Alexa
-  debug: true
+  }
 });
-
-console.log(constants);
-
-module.exports = Object.freeze(constants);

--- a/lambda/custom/constants.js
+++ b/lambda/custom/constants.js
@@ -1,70 +1,29 @@
 'use strict';
+const stringResources = require(process.env.STRING_BRAND);
 
-module.exports = Object.freeze({
+let constants = {};
+constants.strings = stringResources.en.translation;
+
+Object.assign(constants, {
   // App-ID. TODO: set to your own Skill App ID from the developer portal.
   appId: '',
-
   dynamoDBTableName: 'ScoutDB',
 
   /*
-     *  States:
-     *  START_MODE : Welcome state when the audio list has not begun.
-     *  PLAY_MODE :  When a playlist is being played. Does not imply only active play.
-     *               It remains in the state as long as the playlist is not finished.
-     *  RESUME_DECISION_MODE : When a user invokes the skill in PLAY_MODE with a LaunchRequest,
-     *                         the skill provides an option to resume from last position, or to start over the playlist.
-     */
+      *  States:
+      *  START_MODE : Welcome state when the audio list has not begun.
+      *  PLAY_MODE :  When a playlist is being played. Does not imply only active play.
+      *               It remains in the state as long as the playlist is not finished.
+      *  RESUME_DECISION_MODE : When a user invokes the skill in PLAY_MODE with a LaunchRequest,
+      *                         the skill provides an option to resume from last position, or to start over the playlist.
+      */
   states: {
     START_MODE: '',
     PLAY_MODE: '_PLAY_MODE',
     RESUME_DECISION_MODE: '_RESUME_DECISION_MODE',
     TITLES_DECISION_MODE: '_TITLES_DECISION_MODE'
   },
-  strings: {
-    WELCOME_MSG: 'Welcome to Scout. To begin, say get titles.',
-    WELCOME_REPROMPT: 'Begin by saying get my titles.',
-    START_HELP:
-      'To listen to an article say “Play” followed by the title or' +
-      ' a few keywords. For example, say “Play the one about polar bears.” ' +
-      'Say “Get my titles” to hear the first 5 articles in Pocket queue.',
-    TITLE_HELP:
-      'To listen to an article say “Play” followed by the title or' +
-      ' a few keywords. For example, say “Play the one about polar bears.” ' +
-      'Say “Get my titles” to hear the first 5 articles in Pocket queue, ' +
-      'next to hear another 5 and repeat to hear them again.',
-    TITLE_PREFIX: 'Here are the next titles:',
-    END_OF_TITLES: 'There are no more titles in your queue.',
-    TITLE_ANN: 'Here are your titles: ',
-    TITLE_SEARCH_MATCH_FAIL:
-      'Sorry, I couldn’t find a match.  Say Play followed by a few words in the title ' +
-      'or say Repeat to hear the titles again.',
-    ORDINAL_FAIL:
-      "Sorry, you don't have enough titles. " +
-      'Say Play followed by a few words in the title ' +
-      'or say Repeat to hear the titles again.',
-    TITLE_CHOICE_EXPLAIN: 'What would you like to listen to?',
-    TITLE_CHOICE_EXPLAIN_REPROMPT:
-      'What would you like to listen to?' +
-      ' You can say next for more titles.',
-    TITLES_NEXT: 'Here are the next titles: ',
-    TITLES_REPEAT: 'Repeating last titles<break />',
-    TITLE_CHOOSE_SUMM_FULL:
-      'Would you like to hear a summary or the full article?',
-    TITLE_CHOICE_REPROMPT: 'You can say summary or full article.',
-    ARTICLE_FAIL_MSG:
-      'Unable to find the article.  Please try' +
-      ' saying get titles to hear your titles.',
-    ALEXA_STOP_RESP: 'Goodbye!  Thanks for listening to the web with Scout',
-    ERROR_UNHANDLED_STATE:
-      'Sorry, I could not understand. Please say, get titles to hear your titles.',
-    ERROR_UNEXPECTED_STATE: 'Sorry, unhandled intent: in state: ',
-    ERROR_GETTING_TITLES: 'Error Getting titles',
-    PLAY_MODE_UNHANDLED:
-      'Sorry, I could not understand that.  ' +
-      'You can say pause or resume or stop to control the audio',
-    WAIT_ARTICLE: 'One moment while I get that ready for you...',
-    USER_AGENT: 'Alexa Skill'
-  },
+
   metrics: {
     GET_TITLES: 'listen_command',
     START_LISTEN: 'start_listen',
@@ -72,7 +31,12 @@ module.exports = Object.freeze({
     CTX_CMD_GET_TITLES: 'get_titles'
   },
   TITLE_CHUNK_LEN: 5,
+  USER_AGENT: 'Alexa Skill',
 
   // when true, the skill logs additional detail, including the full request received from Alexa
   debug: true
 });
+
+console.log(constants);
+
+module.exports = Object.freeze(constants);

--- a/lambda/custom/pocket_strings.json
+++ b/lambda/custom/pocket_strings.json
@@ -4,8 +4,8 @@
       "LINK_ACCOUNT": "To start using this skill, please use the companion app to authenticate on Amazon. ",
       "WELCOME_MSG": "Welcome to Pocket. To begin, say get articles.",
       "WELCOME_REPROMPT": "Begin by saying get my articles.",
-      "START_HELP": "To listen to an article, say “Play”, followed by the title or a few keywords. For example, say “Play the one about polar bears.” You can say “Get my articles” to hear the first few articles in your Pocket queue.",
-      "TITLE_HELP": "To listen to an article, say “Play”, followed by the title or a few keywords. For example, say “Play the one about polar bears.” You can say “Get my articles” to hear the first few articles in your Pocket queue, next, to hear the next few, and repeat, to hear them again. ",
+      "START_HELP": "To listen to an article, say Play, followed by the title or a few keywords. For example, say Play the one about polar bears. You can say Get my articles to hear the first few articles in your Pocket queue.",
+      "TITLE_HELP": "To listen to an article, say Play, followed by the title or a few keywords. For example, say Play the one about polar bears. You can say Get my articles to hear the first few articles in your Pocket queue, next, to hear the next few, and repeat, to hear them again.",
       "TITLE_PREFIX": "Here are the next articles:",
       "END_OF_TITLES": "There are no more articles in your queue.",
       "TITLE_ANN": "Here are your articles: ",
@@ -23,8 +23,7 @@
       "ERROR_UNEXPECTED_STATE": "Sorry, unhandled intent: in state: ",
       "ERROR_GETTING_TITLES": "Error Getting articles",
       "PLAY_MODE_UNHANDLED": "Sorry, I could not understand that.  You can say pause or resume or stop to control the audio",
-      "WAIT_ARTICLE": "One moment while I get that ready for you...",
-      "USER_AGENT": "Alexa Skill"
+      "WAIT_ARTICLE": "One moment while I get that ready for you..."
     }
   }
 }

--- a/lambda/custom/scout_strings.json
+++ b/lambda/custom/scout_strings.json
@@ -23,8 +23,7 @@
       "ERROR_UNEXPECTED_STATE": "Sorry, unhandled intent: in state: ",
       "ERROR_GETTING_TITLES": "Error Getting titles",
       "PLAY_MODE_UNHANDLED": "Sorry, I could not understand that.  You can say pause or resume or stop to control the audio",
-      "WAIT_ARTICLE": "One moment while I get that ready for you...",
-      "USER_AGENT": "Alexa Skill"
+      "WAIT_ARTICLE": "One moment while I get that ready for you..."
     }
   },
   "de-DE": {

--- a/lambda/custom/scout_strings.json
+++ b/lambda/custom/scout_strings.json
@@ -1,38 +1,28 @@
 {
   "en": {
     "translation": {
-      "LINK_ACCOUNT":
-        "To start using this skill, please use the companion app to authenticate on Amazon. ",
+      "LINK_ACCOUNT": "To start using this skill, please use the companion app to authenticate on Amazon. ",
       "WELCOME_MSG": "Welcome to Scout. To begin, say get titles.",
       "WELCOME_REPROMPT": "Begin by saying get my titles.",
-      "START_HELP":
-        "To listen to an article say “Play” followed by the title or a few keywords. For example, say “Play the one about polar bears.” Say “Get my titles” to hear the first 5 articles in Pocket queue.",
-      "TITLE_HELP":
-        "To listen to an article say “Play” followed by the title or a few keywords. For example, say “Play the one about polar bears.” Say “Get my titles” to hear the first 5 articles in Pocket queue, next to hear another 5 and repeat to hear them again. ",
+      "START_HELP": "To listen to an article, say Play, followed by the title or a few keywords. For example, say Play the one about polar bears. You can say Get my titles to hear the first few articles in your Pocket queue.",
+      "TITLE_HELP": "To listen to an article, say Play, followed by the title or a few keywords. For example, say Play the one about polar bears. You can say Get my titles to hear the first few articles in your Pocket queue, next, to hear the next few, and repeat, to hear them again.",
       "TITLE_PREFIX": "Here are the next titles:",
       "END_OF_TITLES": "There are no more titles in your queue.",
       "TITLE_ANN": "Here are your titles: ",
-      "TITLE_SEARCH_MATCH_FAIL":
-        "Sorry, I couldn’t find a match.  Say Play followed by a few words in the title or say Repeat to hear the titles again.",
-      "ORDINAL_FAIL":
-        "Sorry, you don't have enough titles. Say Play followed by a few words in the title or say Repeat to hear the titles again.",
+      "TITLE_SEARCH_MATCH_FAIL": "Sorry, I couldn’t find a match.  Say Play followed by a few words in the title or say Repeat to hear the titles again.",
+      "ORDINAL_FAIL": "Sorry, you don't have enough titles. Say Play followed by a few words in the title or say Repeat to hear the titles again.",
       "TITLE_CHOICE_EXPLAIN": "What would you like to listen to?",
-      "TITLE_CHOICE_EXPLAIN_REPROMPT":
-        "What would you like to listen to? You can say next for more titles.",
+      "TITLE_CHOICE_EXPLAIN_REPROMPT": "What would you like to listen to? You can say next for more titles.",
       "TITLES_NEXT": "Here are the next titles: ",
       "TITLES_REPEAT": "Repeating last titles<break />",
-      "TITLE_CHOOSE_SUMM_FULL":
-        "Would you like to hear a summary or the full article?",
+      "TITLE_CHOOSE_SUMM_FULL": "Would you like to hear a summary or the full article?",
       "TITLE_CHOICE_REPROMPT": "You can say summary or full article.",
-      "ARTICLE_FAIL_MSG":
-        "Unable to find the article.  Please try saying get titles to hear your titles.",
+      "ARTICLE_FAIL_MSG": "Unable to find the article.  Please try saying get titles to hear your titles.",
       "ALEXA_STOP_RESP": "Goodbye!  Thanks for listening to the web with Scout",
-      "ERROR_UNHANDLED_STATE":
-        "Sorry, I could not understand. Please say, get titles to hear your titles.",
+      "ERROR_UNHANDLED_STATE": "Sorry, I could not understand. Please say, get titles to hear your titles.",
       "ERROR_UNEXPECTED_STATE": "Sorry, unhandled intent: in state: ",
       "ERROR_GETTING_TITLES": "Error Getting titles",
-      "PLAY_MODE_UNHANDLED":
-        "Sorry, I could not understand that.  You can say pause or resume or stop to control the audio",
+      "PLAY_MODE_UNHANDLED": "Sorry, I could not understand that.  You can say pause or resume or stop to control the audio",
       "WAIT_ARTICLE": "One moment while I get that ready for you...",
       "USER_AGENT": "Alexa Skill"
     }

--- a/lambda/custom/state_handlers.js
+++ b/lambda/custom/state_handlers.js
@@ -401,7 +401,7 @@ var scout_agent = (function() {
       'X-Accept': 'application/json',
       Content: 'application/json',
       'x-access-token': process.env.JWOT_TOKEN,
-      'User-Agent': constants.strings.USER_AGENT
+      'User-Agent': constants.USER_AGENT
     }
   };
 
@@ -464,7 +464,7 @@ var scout_agent = (function() {
             'X-Accept': 'application/json',
             Content: 'application/json',
             'x-access-token': process.env.JWOT_TOKEN,
-            'User-Agent': constants.strings.USER_AGENT
+            'User-Agent': constants.USER_AGENT
           }
         };
 

--- a/lambda/custom/test/tests.js
+++ b/lambda/custom/test/tests.js
@@ -2,13 +2,17 @@ var AWS = require('aws-sdk');
 AWS.config.update({ region: 'us-east-1' });
 const assert = require('chai').assert;
 const vax = require('virtual-alexa');
-const constants = require('../constants');
+const stringResources = require(`../${process.env.STRING_BRAND}`);
 const logger = require('../logger');
 
 if (!process.env.SCOUT_ADDR || !process.env.JWOT_TOKEN) {
   logger.error('No env vars found.');
   throw new Error('No env vars found. Please add SCOUT_ADDR and JWOT_TOKEN.');
 }
+
+// Load Alexa strings
+const constants = {};
+constants.strings = stringResources.en.translation;
 
 const alexa = vax.VirtualAlexa.Builder()
   .handler('index.handler') // Lambda function file and name


### PR DESCRIPTION
There were duplicate declarations for the Scout branding strings (scout_strings.js and constants.js). This change removes them from the constants class since they are now passed in to the skill directly via the brand file. 

Updated the integration tests to also read strings from the brand file (as specified in the STRING_BRAND env variable) so now tests will pass with both the Scout and Pocket brand files. 